### PR TITLE
Chore/update `twine` to 5.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2022,13 +2022,13 @@ xarray = ["xarray"]
 
 [[package]]
 name = "pkginfo"
-version = "1.11.1"
+version = "1.10.0"
 description = "Query metadata from sdists / bdists / installed packages."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.6"
 files = [
-    {file = "pkginfo-1.11.1-py3-none-any.whl", hash = "sha256:bfa76a714fdfc18a045fcd684dbfc3816b603d9d075febef17cb6582bea29573"},
-    {file = "pkginfo-1.11.1.tar.gz", hash = "sha256:2e0dca1cf4c8e39644eed32408ea9966ee15e0d324c62ba899a393b3c6b467aa"},
+    {file = "pkginfo-1.10.0-py3-none-any.whl", hash = "sha256:889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097"},
+    {file = "pkginfo-1.10.0.tar.gz", hash = "sha256:5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297"},
 ]
 
 [package.extras]
@@ -2927,19 +2927,19 @@ testing = ["build[virtualenv] (>=1.0.3)", "covdefaults (>=2.3)", "detect-test-po
 
 [[package]]
 name = "twine"
-version = "5.1.0"
+version = "5.1.1"
 description = "Collection of utilities for publishing packages on PyPI"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "twine-5.1.0-py3-none-any.whl", hash = "sha256:fe1d814395bfe50cfbe27783cb74efe93abeac3f66deaeb6c8390e4e92bacb43"},
-    {file = "twine-5.1.0.tar.gz", hash = "sha256:4d74770c88c4fcaf8134d2a6a9d863e40f08255ff7d8e2acb3cbbd57d25f6e9d"},
+    {file = "twine-5.1.1-py3-none-any.whl", hash = "sha256:215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997"},
+    {file = "twine-5.1.1.tar.gz", hash = "sha256:9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db"},
 ]
 
 [package.dependencies]
 importlib-metadata = ">=3.6"
 keyring = ">=15.1"
-pkginfo = ">=1.8.1"
+pkginfo = ">=1.8.1,<1.11"
 readme-renderer = ">=35.0"
 requests = ">=2.20"
 requests-toolbelt = ">=0.8.0,<0.9.0 || >0.9.0"
@@ -3224,4 +3224,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4808e21c3c301ccae27151e7289356b010702a5a6033ebdb6409bfb4bd1c5045"
+content-hash = "18e222c6dad4e586ace3f58dd67479bb7829c2e36f3c3ebc736b4f127d4a4e16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ pytest-cov = "5.0.0"
 pytest-loguru = "0.4.0"
 ruff = "0.4.9"
 tox = "4.15.1"
-twine = "5.1.0"
+twine = "5.1.1"
 
 
 [tool.poetry.group.docs.dependencies]
@@ -63,7 +63,7 @@ mkdocs-material-extensions = "1.3.1"
 mkdocs-section-index = "0.3.9"
 mkdocstrings = "0.25.1"
 mkdocstrings-python = "1.10.3"
-pkginfo = "^1.11.1"
+pkginfo = "<1.11"
 setuptools = "^70.0.0"
 virtualenv = "^20.26.2"
 


### PR DESCRIPTION
The locked version 5.1.0 for twine is a yanked version. Reason for being yanked: https://github.com/pypa/twine/issues/1125