### PR TITLE
Feature/add coach class rating

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.1"
+current_version = "0.9.2"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<dev_l>dev)(?P<dev>0|[1-9]\\d*))?"
 

--- a/examples/workout_examples.py
+++ b/examples/workout_examples.py
@@ -80,7 +80,7 @@ def main():
 
     # you can get detailed information about a specific performance summary by calling `get_performance_summary`
     # which takes a performance_summary_id as an argument
-    data = otf.get_performance_summary(data_list[0].id)
+    data = otf.get_performance_summary(data_list[0].class_history_uuid)
     print(data.model_dump_json(indent=4))
 
     """
@@ -207,7 +207,7 @@ def main():
     # telemetry is a detailed record of a specific workout - minute by minute, or more granular if desired
     # this endpoint takes a class_history_uuid, as well as a number of max data points (default 120)
 
-    telemetry = otf.get_telemetry(performance_summary_id=data_list[1].id)
+    telemetry = otf.get_telemetry(performance_summary_id=data_list[1].class_history_uuid)
     telemetry.telemetry = telemetry.telemetry[:2]
     print(telemetry.model_dump_json(indent=4))
 

--- a/examples/workout_examples.py
+++ b/examples/workout_examples.py
@@ -78,6 +78,52 @@ def main():
     }
     """
 
+    # if you want to rate a class you can do that with the `rate_class_from_performance_summary` method
+    # this method takes a performance_summary object, as well as a coach_rating and class_rating
+    # the ratings are integers from 1 - 3
+    # the method returns an updated PerformanceSummaryEntry object
+
+    # if you already rated the class it will return an exception
+    # likewise if the class is not ratable (seems to be an age cutoff) or if the class is not found
+
+    res = otf.rate_class_from_performance_summary(data_list[0], 3, 3)
+    print(res.model_dump_json(indent=4))
+
+    """
+    {
+        "id": "c39e7cde-5e02-4e1a-89e2-d41e8a4653b3",
+        "calories_burned": 250,
+        "splat_points": 0,
+        "step_count": 0,
+        "active_time_seconds": 2687,
+        "zone_time_minutes": {
+            "gray": 17,
+            "blue": 24,
+            "green": 4,
+            "orange": 0,
+            "red": 0
+        },
+        "ratable": true,
+        "otf_class": {
+            "class_uuid": "23c8ad3e-4257-431c-b5f0-8313d8d82434",
+            "starts_at": "2025-01-18T10:30:00",
+            "name": "Tread 50 / Strength 50",
+            "type": "STRENGTH_50"
+        },
+        "coach": "Bobby",
+        "coach_rating": {
+            "id": "18",
+            "description": "Double Thumbs Up",
+            "value": 3
+        },
+        "class_rating": {
+            "id": "21",
+            "description": "Double Thumbs Up",
+            "value": 3
+        }
+    }
+    """
+
     # you can get detailed information about a specific performance summary by calling `get_performance_summary`
     # which takes a performance_summary_id as an argument
     data = otf.get_performance_summary(data_list[0].class_history_uuid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "otf-api"
-version = "0.9.1"
+version = "0.9.2"
 description = "Python OrangeTheory Fitness API Client"
 authors = ["Jessica Smith <j.smith.git1@gmail.com>"]
 license = "MIT"

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -4,7 +4,7 @@ from otf_api.api import Otf
 from otf_api import models
 from otf_api.auth import OtfUser
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/api.py
+++ b/src/otf_api/api.py
@@ -87,9 +87,7 @@ class Otf:
             LOGGER.exception(f"Response: {response.text}")
             raise
         except httpx.HTTPStatusError as e:
-            LOGGER.exception(f"Error making request: {e}")
-            LOGGER.exception(f"Response: {response.text}")
-            raise exc.OtfRequestError("Error making request", response=response, request=request)
+            raise exc.OtfRequestError("Error making request", e, response=response, request=request)
         except Exception as e:
             LOGGER.exception(f"Error making request: {e}")
             raise
@@ -110,7 +108,7 @@ class Otf:
             and not (resp["Status"] >= 200 and resp["Status"] <= 299)
         ):
             LOGGER.error(f"Error making request: {resp}")
-            raise exc.OtfRequestError("Error making request", response=response, request=request)
+            raise exc.OtfRequestError("Error making request", None, response=response, request=request)
 
         return resp
 
@@ -966,6 +964,7 @@ class Otf:
 
         path = f"/v1/performance-summaries/{performance_summary_id}"
         res = self._performance_summary_request("GET", path)
+
         if res is None:
             raise exc.ResourceNotFoundError(f"Performance summary {performance_summary_id} not found")
 

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -51,3 +51,11 @@ class BookingNotFoundError(OtfException):
 
 class ResourceNotFoundError(OtfException):
     """Raised when a resource is not found."""
+
+
+class AlreadyRatedError(OtfException):
+    """Raised when attempting to rate a class that is already rated."""
+
+
+class ClassNotRatableError(OtfException):
+    """Raised when attempting to rate a class that is not ratable."""

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -8,11 +8,13 @@ class OtfException(Exception):
 class OtfRequestError(OtfException):
     """Raised when an error occurs while making a request to the OTF API."""
 
+    original_exception: Exception
     response: Response
     request: Request
 
-    def __init__(self, message: str, response: Response, request: Request):
+    def __init__(self, message: str, original_exception: Exception | None, response: Response, request: Request):
         super().__init__(message)
+        self.original_exception = original_exception
         self.response = response
         self.request = request
 

--- a/src/otf_api/models/performance_summary_detail.py
+++ b/src/otf_api/models/performance_summary_detail.py
@@ -68,11 +68,16 @@ class Rower(BaseEquipment):
 
 
 class PerformanceSummaryDetail(OtfItemBase):
-    id: str
+    class_history_uuid: str = Field(..., alias="id")
     class_name: str | None = Field(None, alias=AliasPath("class", "name"))
     class_starts_at: datetime | None = Field(None, alias=AliasPath("class", "starts_at_local"))
 
-    ratable: bool | None = None
+    ratable: bool | None = Field(
+        None,
+        exclude=True,
+        repr=False,
+        description="Seems to be inaccurate, not reflecting ratable from `PerformanceSummaryEntry`",
+    )
     calories_burned: int | None = Field(None, alias=AliasPath("details", "calories_burned"))
     splat_points: int | None = Field(None, alias=AliasPath("details", "splat_points"))
     step_count: int | None = Field(None, alias=AliasPath("details", "step_count"))

--- a/src/otf_api/models/performance_summary_list.py
+++ b/src/otf_api/models/performance_summary_list.py
@@ -33,7 +33,7 @@ class ClassRating(OtfItemBase):
 
 
 class PerformanceSummaryEntry(OtfItemBase):
-    id: str = Field(..., alias="id")
+    class_history_uuid: str = Field(..., alias="id")
     calories_burned: int | None = Field(None, alias=AliasPath("details", "calories_burned"))
     splat_points: int | None = Field(None, alias=AliasPath("details", "splat_points"))
     step_count: int | None = Field(None, alias=AliasPath("details", "step_count"))


### PR DESCRIPTION
- add functionality to rate a class
- add exceptions for new method
- don't log exception when re-raising OtfRequestError, to avoid logging errors that we will be reframing/changing
- rename performance summary entry/detail `id` attribute to `class_history_uuid`
- add method for getting a performance summary entry from a `class_history_uuid`, since this model is the only one that has all the pieces to rate a class