### PR TITLE
fix: use correct attribute for cache directory

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.9.2"
+current_version = "0.9.3"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<dev_l>dev)(?P<dev>0|[1-9]\\d*))?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "otf-api"
-version = "0.9.2"
+version = "0.9.3"
 description = "Python OrangeTheory Fitness API Client"
 authors = ["Jessica Smith <j.smith.git1@gmail.com>"]
 license = "MIT"

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -4,7 +4,7 @@ from otf_api.api import Otf
 from otf_api import models
 from otf_api.auth import OtfUser
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/utils.py
+++ b/src/otf_api/utils.py
@@ -67,7 +67,7 @@ class CacheableData:
     cache_dir: Path
 
     def __attrs_post_init__(self):
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.cache_path.mkdir(parents=True, exist_ok=True)
 
     @property
     def cache_path(self) -> Path:


### PR DESCRIPTION
Use `cache_path` instead of `cache_dir` to actually use the expanded path and not make a folder named `~` in the current directory