### PR TITLE
add logic to return a value if studio endpoint raises ResourceNotFound

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.10.0"
+current_version = "0.10.1"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<dev_l>dev)(?P<dev>0|[1-9]\\d*))?"
 

--- a/examples/studio_examples.py
+++ b/examples/studio_examples.py
@@ -95,6 +95,35 @@ def main():
     # you can remove a studio from your favorites by calling `remove_favorite_studio` with a studio_uuid
     otf.remove_favorite_studio(otf.home_studio_uuid)
 
+    # if you attempt to get a studio that doesn't exist, you'll a mostly empty studio detail object
+    # with the studio uuid set to the provided value
+    # this allows you to avoid dealing with None values + you can still group or sort by studio_uuid
+
+    invalid_studio = otf.get_studio_detail("2d07e9fc-cd14-4d5b-840e-09eb2b614c6c")
+    assert invalid_studio.studio_uuid == "2d07e9fc-cd14-4d5b-840e-09eb2b614c6c"
+    print(invalid_studio.model_dump_json(indent=4))
+
+    """
+    {
+        "studio_uuid": "2d07e9fc-cd14-4d5b-840e-09eb2b614c6c",
+        "contact_email": null,
+        "location": {
+            "address_line1": null,
+            "address_line2": null,
+            "city": null,
+            "postal_code": null,
+            "state": null,
+            "country": null,
+            "phone_number": null,
+            "latitude": null,
+            "longitude": null
+        },
+        "name": "Studio Not Found",
+        "status": "Unknown",
+        "time_zone": null
+    }
+    """
+
 
 if __name__ == "__main__":
     main()

--- a/examples/workout_examples.py
+++ b/examples/workout_examples.py
@@ -129,7 +129,7 @@ def main():
 
     # you can get detailed information about a specific performance summary by calling `get_performance_summary`
     # which takes a performance_summary_id as an argument
-    data = otf.get_performance_summary(data_list[0].class_history_uuid)
+    data = otf.get_performance_summary(data_list[0].performance_summary_id)
     print(data.model_dump_json(indent=4))
 
     """
@@ -254,16 +254,16 @@ def main():
     """
 
     # telemetry is a detailed record of a specific workout - minute by minute, or more granular if desired
-    # this endpoint takes a class_history_uuid, as well as a number of max data points (default 120)
+    # this endpoint takes a performance_summary_id, as well as a number of max data points (default 120)
 
-    telemetry = otf.get_telemetry(performance_summary_id=data_list[1].class_history_uuid)
+    telemetry = otf.get_telemetry(performance_summary_id=data_list[1].performance_summary_id)
     telemetry.telemetry = telemetry.telemetry[:2]
     print(telemetry.model_dump_json(indent=4))
 
     """
     {
         "member_uuid": "7d2f2b96-7e03-426e-b1dd-39491b79222f",
-        "class_history_uuid": "fcff805a-4e0c-4606-9976-5e85a54dc972",
+        "performance_summary_id": "fcff805a-4e0c-4606-9976-5e85a54dc972",
         "class_start_time": "2025-01-16T15:47:25Z",
         "max_hr": 191,
         "zones": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "otf-api"
-version = "0.10.0"
+version = "0.10.1"
 description = "Python OrangeTheory Fitness API Client"
 authors = ["Jessica Smith <j.smith.git1@gmail.com>"]
 license = "MIT"

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -4,7 +4,7 @@ from otf_api.api import Otf
 from otf_api import models
 from otf_api.auth import OtfUser
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/api.py
+++ b/src/otf_api/api.py
@@ -919,6 +919,8 @@ class Otf:
         """Get detailed information about a specific studio. If no studio UUID is provided, it will default to the
         user's home studio.
 
+        If the studio is not found, it will return a StudioDetail object with default values.
+
         Args:
             studio_uuid (str, optional): The studio UUID to get detailed information about.
 
@@ -926,7 +928,11 @@ class Otf:
             StudioDetail: Detailed information about the studio.
         """
         studio_uuid = studio_uuid or self.home_studio_uuid
-        res = self._get_studio_detail_raw(studio_uuid)
+
+        try:
+            res = self._get_studio_detail_raw(studio_uuid)
+        except exc.ResourceNotFoundError:
+            return models.StudioDetail(studioUUId=studio_uuid, studioName="Studio Not Found", studioStatus="Unknown")
 
         return models.StudioDetail(**res["data"])
 

--- a/src/otf_api/api.py
+++ b/src/otf_api/api.py
@@ -1,7 +1,6 @@
 import atexit
 import contextlib
 import functools
-import warnings
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import date, datetime, timedelta
@@ -177,9 +176,10 @@ class Otf:
         """Retrieve raw member membership details."""
         return self._default_request("GET", f"/member/members/{self.member_uuid}/memberships")
 
-    def _get_performance_summaries_raw(self) -> dict:
+    def _get_performance_summaries_raw(self, limit: int | None = None) -> dict:
         """Retrieve raw performance summaries data."""
-        return self._performance_summary_request("GET", "/v1/performance-summaries")
+        params = {"limit": limit} if limit else {}
+        return self._performance_summary_request("GET", "/v1/performance-summaries", params=params)
 
     def _get_performance_summary_raw(self, performance_summary_id: str) -> dict:
         """Retrieve raw performance summary data."""
@@ -1111,8 +1111,11 @@ class Otf:
         return models.FitnessBenchmark(**data["Dto"][0])
 
     @cached(cache=TTLCache(maxsize=1024, ttl=600))
-    def get_performance_summaries_dict(self) -> dict[str, models.PerformanceSummary]:
+    def get_performance_summaries_dict(self, limit: int | None = None) -> dict[str, models.PerformanceSummary]:
         """Get a dictionary of performance summaries for the authenticated user.
+
+        Args:
+            limit (int | None): The maximum number of entries to return. Default is None.
 
         Returns:
             dict[str, PerformanceSummary]: A dictionary of performance summaries, keyed by class history UUID.
@@ -1123,7 +1126,7 @@ class Otf:
 
         """
 
-        items = self._get_performance_summaries_raw()["items"]
+        items = self._get_performance_summaries_raw(limit=limit)["items"]
 
         distinct_studio_ids = set([rec["class"]["studio"]["id"] for rec in items])
         perf_summary_ids = set([rec["id"] for rec in items])
@@ -1149,7 +1152,7 @@ class Otf:
         """Get a list of all performance summaries for the authenticated user.
 
         Args:
-            limit (int | None): The maximum number of entries to return. Default is None. Deprecated.
+            limit (int | None): The maximum number of entries to return. Default is None.
 
         Returns:
             list[PerformanceSummary]: A list of performance summaries.
@@ -1160,26 +1163,33 @@ class Otf:
 
         """
 
-        if limit:
-            warnings.warn("Limit is deprecated and will be removed in a future version.", DeprecationWarning)
-
-        records = list(self.get_performance_summaries_dict().values())
+        records = list(self.get_performance_summaries_dict(limit=limit).values())
 
         sorted_records = sorted(records, key=lambda x: x.otf_class.starts_at, reverse=True)
 
         return sorted_records
 
-    def get_performance_summary(self, performance_summary_id: str) -> models.PerformanceSummary:
+    def get_performance_summary(
+        self, performance_summary_id: str, limit: int | None = None
+    ) -> models.PerformanceSummary:
         """Get performance summary for a given workout.
+
+        Note: Due to the way the OTF API is set up, we have to call both the list and the get endpoints. By
+        default this will call the list endpoint with no limit, in order to ensure that the performance summary
+        is returned if it exists. This could result in a lot of requests, so you also have the option to provide
+        a limit to only fetch a certain number of performance summaries.
 
         Args:
             performance_summary_id (str): The ID of the performance summary to retrieve.
 
         Returns:
             PerformanceSummary: The performance summary.
+
+        Raises:
+            ResourceNotFoundError: If the performance_summary_id is not in the list of performance summaries.
         """
 
-        perf_summary = self.get_performance_summaries_dict().get(performance_summary_id)
+        perf_summary = self.get_performance_summaries_dict(limit=limit).get(performance_summary_id)
 
         if perf_summary is None:
             raise exc.ResourceNotFoundError(f"Performance summary {performance_summary_id} not found")
@@ -1188,7 +1198,7 @@ class Otf:
 
     @functools.lru_cache(maxsize=1024)
     def _get_performancy_summary_detail(self, performance_summary_id: str) -> dict[str, Any]:
-        """Get the details for a performance summary.
+        """Get the details for a performance summary. Generally should not be called directly. This
 
         Args:
             performance_summary_id (str): The performance summary ID.

--- a/src/otf_api/models/enums.py
+++ b/src/otf_api/models/enums.py
@@ -8,6 +8,7 @@ class StudioStatus(StrEnum):
     COMING_SOON = "Coming Soon"
     TEMP_CLOSED = "Temporarily Closed"
     PERM_CLOSED = "Permanently Closed"
+    UNKNOWN = "Unknown"
 
 
 class BookingStatus(StrEnum):

--- a/src/otf_api/models/performance_summary.py
+++ b/src/otf_api/models/performance_summary.py
@@ -105,7 +105,8 @@ class PerformanceSummary(OtfItemBase):
 
     """
 
-    class_history_uuid: str = Field(..., alias="id")
+    performance_summary_id: str = Field(..., alias="id", description="Unique identifier for this performance summary")
+    class_history_uuid: str = Field(..., alias="id", description="Same as performance_summary_id")
     ratable: bool | None = None
     otf_class: Class | None = Field(None, alias="class")
     coach: str | None = Field(None, alias=AliasPath("class", "coach", "first_name"))

--- a/src/otf_api/models/studio_detail.py
+++ b/src/otf_api/models/studio_detail.py
@@ -9,8 +9,8 @@ from otf_api.models.mixins import AddressMixin
 
 class StudioLocation(AddressMixin):
     phone_number: str | None = Field(None, alias=AliasChoices("phone", "phoneNumber"))
-    latitude: float = Field(..., alias=AliasChoices("latitude"))
-    longitude: float = Field(..., alias=AliasChoices("longitude"))
+    latitude: float | None = Field(None, alias=AliasChoices("latitude"))
+    longitude: float | None = Field(None, alias=AliasChoices("longitude"))
 
     physical_region: str | None = Field(None, alias="physicalRegion", exclude=True, repr=False)
     physical_country_id: int | None = Field(None, alias="physicalCountryId", exclude=True, repr=False)
@@ -27,7 +27,7 @@ class StudioDetail(OtfItemBase):
         exclude=True,
         repr=False,
     )
-    location: StudioLocation = Field(..., alias="studioLocation")
+    location: StudioLocation = Field(..., alias="studioLocation", default_factory=StudioLocation)
     name: str | None = Field(None, alias="studioName")
     status: StudioStatus | None = Field(
         None, alias="studioStatus", description="Active, Temporarily Closed, Coming Soon"

--- a/src/otf_api/models/telemetry.py
+++ b/src/otf_api/models/telemetry.py
@@ -49,7 +49,10 @@ class TelemetryItem(OtfItemBase):
 
 class Telemetry(OtfItemBase):
     member_uuid: str = Field(..., alias="memberUuid")
-    class_history_uuid: str = Field(..., alias="classHistoryUuid")
+    performance_summary_id: str = Field(
+        ..., alias="classHistoryUuid", description="The ID of the performance summary this telemetry item belongs to."
+    )
+    class_history_uuid: str = Field(..., alias="classHistoryUuid", description="The same as performance_summary_id.")
     class_start_time: datetime | None = Field(None, alias="classStartTime")
     max_hr: int | None = Field(None, alias="maxHr")
     zones: Zones


### PR DESCRIPTION
- align on `performance_summary_id` (previously had mix of performance_summary_id and class_history_uuid)
- bring back `limit` functionality for performance summaries
- return empty StudioDetail with provided studio_uuid if studio endpoint returns 404

Closes #78 