### PR TITLE
Feature/compatibility

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.11.1"
+current_version = "0.12.0"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<rc_l>rc)(?P<rc>0|[1-9]\\d*))?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "otf-api"
-version = "0.11.1"
+version = "0.12.0"
 description = "Python OrangeTheory Fitness API Client"
 authors = [{ name = "Jessica Smith", email = "j.smith.git1@gmail.com" }]
 requires-python = ">=3.11"

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -4,7 +4,7 @@ from otf_api.api import Otf
 from otf_api import models
 from otf_api.auth import OtfUser
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/models/bookings.py
+++ b/src/otf_api/models/bookings.py
@@ -36,6 +36,11 @@ class OtfClass(OtfItemBase):
     program_name: str | None = Field(None, alias="programName", exclude=True, repr=False)
     virtual_class: bool | None = Field(None, alias="virtualClass", exclude=True, repr=False)
 
+    @property
+    def coach_name(self) -> str:
+        """Shortcut to get the coach's name, to be compatible with new BookingV2Class"""
+        return self.coach.first_name or ""
+
     def __str__(self) -> str:
         starts_at_str = self.starts_at.strftime("%a %b %d, %I:%M %p")
         return f"Class: {starts_at_str} {self.name} - {self.coach.first_name}"
@@ -89,6 +94,11 @@ class Booking(OtfItemBase):
     def ends_at(self) -> datetime:
         """Shortcut to get the class end time"""
         return self.otf_class.ends_at
+
+    @property
+    def id_value(self) -> str:
+        """Returns the booking_uuid, to be compatible with new BookingV2 model"""
+        return self.booking_uuid
 
     def __str__(self) -> str:
         starts_at_str = self.otf_class.starts_at.strftime("%a %b %d, %I:%M %p")

--- a/src/otf_api/models/bookings_v2.py
+++ b/src/otf_api/models/bookings_v2.py
@@ -72,6 +72,16 @@ class BookingV2Class(OtfItemBase):
     )
     starts_at_utc: datetime | None = Field(None, alias="starts_at", exclude=True, repr=False)
 
+    @property
+    def coach_name(self) -> str:
+        """Shortcut to get the coach's name, to be compatible with old Booking OtfClass model"""
+        return self.coach or ""
+
+    @property
+    def ends_at(self) -> datetime:
+        """Emulates the end time of the class, to be compatible with old Booking OtfClass model"""
+        return get_end_time(self.starts_at, self.class_type)
+
     def __str__(self) -> str:
         starts_at_str = self.starts_at.strftime("%a %b %d, %I:%M %p")
         return f"Class: {starts_at_str} {self.name} - {self.coach}"
@@ -160,7 +170,17 @@ class BookingV2(OtfItemBase):
     @property
     def ends_at(self) -> datetime:
         """Shortcut to get the class end time"""
-        return get_end_time(self.otf_class.starts_at, self.otf_class.class_type)
+        return self.otf_class.ends_at
+
+    @property
+    def cancelled_date(self) -> datetime | None:
+        """Returns the canceled_at value in a backward-compatible way"""
+        return self.canceled_at
+
+    @property
+    def id_value(self) -> str:
+        """Returns the booking_id, to be compatible with old Booking model"""
+        return self.booking_id
 
     def __str__(self) -> str:
         starts_at_str = self.otf_class.starts_at.strftime("%a %b %d, %I:%M %p")

--- a/src/otf_api/utils.py
+++ b/src/otf_api/utils.py
@@ -1,6 +1,6 @@
 import json
 import typing
-from datetime import date, datetime
+from datetime import date, datetime, time
 from logging import getLogger
 from pathlib import Path
 from typing import Any
@@ -11,6 +11,8 @@ if typing.TYPE_CHECKING:
     from otf_api import models
 
 LOGGER = getLogger(__name__)
+
+MIN_TIME = datetime.min.time()
 
 
 def get_booking_uuid(booking_or_uuid: "str | models.Booking") -> str:
@@ -58,7 +60,7 @@ def ensure_list(obj: list | Any | None) -> list:
     return obj
 
 
-def ensure_datetime(date_str: str | datetime | None) -> datetime | None:
+def ensure_datetime(date_str: str | datetime | None, combine_with: time = MIN_TIME) -> datetime | None:
     if not date_str:
         return None
 
@@ -69,7 +71,7 @@ def ensure_datetime(date_str: str | datetime | None) -> datetime | None:
         return date_str
 
     if isinstance(date_str, date):
-        return datetime.combine(date_str, datetime.min.time())
+        return datetime.combine(date_str, combine_with)
 
     raise ValueError(f"Expected str or datetime, got {type(date_str)}")
 


### PR DESCRIPTION
- rename `exclude_canceled` to `exclude_cancelled` in `get_bookings_new`
- rename `start_dtme` and `end_dtme` to `start_date` and `end_date` in `get_bookings_new` - update type annotation to accept dates
  - update `ensure_datetime` to allow providing the time value to combine with a date, so we can get the end of a day where that makes more sense
- add `id_value` to `Booking` and `BookingV2` model
- add `cancelled_date` property to `BookingV2`
- move `ends_at` to `BookingV2Class` model instead of `BookingV2` - keeps as property on `BookingV2`
- add `coach_name` to `BookingV2Class` and `OtfClass` from booking module