### PR TITLE
Fix/pass otf to create method

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.13.0"
+current_version = "0.13.1"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<rc_l>rc)(?P<rc>0|[1-9]\\d*))?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "otf-api"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python OrangeTheory Fitness API Client"
 authors = [{ name = "Jessica Smith", email = "j.smith.git1@gmail.com" }]
 requires-python = ">=3.11"

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../src"))  # type: ignore # noqa
 project = "OrangeTheory API"
 copyright = "2025, Jessica Smith"
 author = "Jessica Smith"
-release = "0.13.0"
+release = "0.13.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -36,7 +36,7 @@ def _setup_logging() -> None:
 
 _setup_logging()
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -80,7 +80,7 @@ class BookingApi:
             ends_before=end_date, starts_after=start_date, include_canceled=include_canceled, expand=expand
         )
 
-        results = [models.BookingV2.create(**b, api=self) for b in bookings_resp]
+        results = [models.BookingV2.create(**b, api=self.otf) for b in bookings_resp]
 
         if not remove_duplicates:
             return results
@@ -228,7 +228,7 @@ class BookingApi:
             raise ValueError("booking_uuid is required")
 
         data = self.client.get_booking(booking_uuid)
-        return models.Booking.create(**data, api=self)
+        return models.Booking.create(**data, api=self.otf)
 
     def get_booking_from_class(self, otf_class: str | models.OtfClass) -> models.Booking:
         """Get a specific booking by class_uuid or OtfClass object.
@@ -337,7 +337,7 @@ class BookingApi:
 
         resp = self.client.post_class_new(body)
 
-        new_booking = models.BookingV2.create(**resp, api=self)
+        new_booking = models.BookingV2.create(**resp, api=self.otf)
 
         return new_booking
 
@@ -443,7 +443,7 @@ class BookingApi:
             b["class"]["studio"] = studios[b["class"]["studio"]["studioUUId"]]
             b["is_home_studio"] = b["class"]["studio"].studio_uuid == self.otf.home_studio_uuid
 
-        bookings = [models.Booking.create(**b, api=self) for b in resp]
+        bookings = [models.Booking.create(**b, api=self.otf) for b in resp]
         bookings = sorted(bookings, key=lambda x: x.otf_class.starts_at)
 
         if exclude_cancelled:

--- a/src/otf_api/api/members/member_api.py
+++ b/src/otf_api/api/members/member_api.py
@@ -134,7 +134,7 @@ class MemberApi:
 
         res = self.client.put_member_name(first_name, last_name)
 
-        return models.MemberDetail.create(**res, api=self)
+        return models.MemberDetail.create(**res, api=self.otf)
 
     def get_member_detail(self) -> models.MemberDetail:
         """Get the member details.
@@ -148,7 +148,7 @@ class MemberApi:
         home_studio_uuid = data["homeStudio"]["studioUUId"]
         data["home_studio"] = self.otf.studios.get_studio_detail(home_studio_uuid)
 
-        return models.MemberDetail.create(**data, api=self)
+        return models.MemberDetail.create(**data, api=self.otf)
 
     def get_member_membership(self) -> models.MemberMembership:
         """Get the member's membership details.

--- a/src/otf_api/api/studios/studio_api.py
+++ b/src/otf_api/api/studios/studio_api.py
@@ -56,7 +56,7 @@ class StudioApi:
 
         new_faves = resp.get("studios", [])
 
-        return [models.StudioDetail.create(**studio, api=self) for studio in new_faves]
+        return [models.StudioDetail.create(**studio, api=self.otf) for studio in new_faves]
 
     def remove_favorite_studio(self, studio_uuids: list[str] | str) -> None:
         """Remove a studio from the member's favorite studios.
@@ -116,7 +116,7 @@ class StudioApi:
         except exc.ResourceNotFoundError:
             return models.StudioDetail.create_empty_model(studio_uuid)
 
-        return models.StudioDetail.create(**res, api=self)
+        return models.StudioDetail.create(**res, api=self.otf)
 
     def get_studios_by_geo(
         self, latitude: float | None = None, longitude: float | None = None
@@ -141,7 +141,7 @@ class StudioApi:
         longitude = longitude or self.otf.home_studio.location.longitude
 
         results = self.client.get_studios_by_geo(latitude, longitude, distance)
-        return [models.StudioDetail.create(**studio, api=self) for studio in results]
+        return [models.StudioDetail.create(**studio, api=self.otf) for studio in results]
 
     def _get_all_studios(self) -> list[models.StudioDetail]:
         """Gets all studios. Marked as private to avoid random users calling it.
@@ -153,7 +153,7 @@ class StudioApi:
         """
         # long/lat being None will cause the endpoint to return all studios
         results = self.client.get_studios_by_geo(None, None)
-        return [models.StudioDetail.create(**studio, api=self) for studio in results]
+        return [models.StudioDetail.create(**studio, api=self.otf) for studio in results]
 
     def _get_studio_detail_threaded(self, studio_uuids: list[str]) -> dict[str, models.StudioDetail]:
         """Get detailed information about multiple studios in a threaded manner.
@@ -169,5 +169,6 @@ class StudioApi:
         """
         studio_dicts = self.client.get_studio_detail_threaded(studio_uuids)
         return {
-            studio_uuid: models.StudioDetail.create(**studio, api=self) for studio_uuid, studio in studio_dicts.items()
+            studio_uuid: models.StudioDetail.create(**studio, api=self.otf)
+            for studio_uuid, studio in studio_dicts.items()
         }

--- a/src/otf_api/api/workouts/workout_api.py
+++ b/src/otf_api/api/workouts/workout_api.py
@@ -237,7 +237,7 @@ class WorkoutApi:
 
         perf_summary = self.client.get_performance_summary(booking.workout.performance_summary_id)
         telemetry = self.get_telemetry(booking.workout.performance_summary_id)
-        workout = models.Workout.create(**perf_summary, v2_booking=booking, telemetry=telemetry, api=self)
+        workout = models.Workout.create(**perf_summary, v2_booking=booking, telemetry=telemetry, api=self.otf)
 
         return workout
 


### PR DESCRIPTION
- after migrating to separate apis, calls to the `create` method of models were still passing `self` instead of the actual `Otf` class instance