### PR TITLE
Feature/add get class from booking

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.14.1"
+current_version = "0.15.0"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<rc_l>rc)(?P<rc>0|[1-9]\\d*))?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "otf-api"
-version = "0.14.1"
+version = "0.15.0"
 description = "Python OrangeTheory Fitness API Client"
 authors = [{ name = "Jessica Smith", email = "j.smith.git1@gmail.com" }]
 requires-python = ">=3.11"

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../src"))  # type: ignore # noqa
 project = "OrangeTheory API"
 copyright = "2025, Jessica Smith"
 author = "Jessica Smith"
-release = "0.14.1"
+release = "0.15.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -36,7 +36,7 @@ def _setup_logging() -> None:
 
 _setup_logging()
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -388,7 +388,7 @@ class BookingApi:
             AlreadyBookedError: If the class is already booked.
             OutsideSchedulingWindowError: If the class is outside the scheduling window.
             ValueError: If class_uuid is None or empty string.
-            OtfException: If there is an error booking the class.
+            OtfError: If there is an error booking the class.
         """
         class_uuid = utils.get_class_uuid(otf_class)
 
@@ -429,7 +429,7 @@ class BookingApi:
             BookingV2: The booking.
 
         Raises:
-            OtfException: If there is an error booking the class.
+            OtfError: If there is an error booking the class.
             TypeError: If the input is not a string or BookingV2Class.
         """
         class_id = utils.get_class_id(class_id)

--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -240,7 +240,7 @@ class BookingApi:
             Booking: The booking.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If class_uuid is None or empty string.
         """
         class_uuid = utils.get_class_uuid(otf_class)
@@ -250,7 +250,7 @@ class BookingApi:
         if booking := next((b for b in all_bookings if b.class_uuid == class_uuid), None):
             return booking
 
-        raise exc.BookingNotFoundError(f"Booking for class {class_uuid} not found.")
+        raise exc.ResourceNotFoundError(f"Booking for class {class_uuid} not found.")
 
     def get_booking_from_class_new(self, otf_class: str | models.OtfClass | models.BookingV2Class) -> models.BookingV2:
         """Get a specific booking by class_uuid or OtfClass object.
@@ -262,7 +262,7 @@ class BookingApi:
             BookingV2: The booking.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If class_uuid is None or empty string.
         """
         class_uuid = utils.get_class_uuid(otf_class)
@@ -272,7 +272,7 @@ class BookingApi:
         if booking := next((b for b in all_bookings if b.class_uuid == class_uuid), None):
             return booking
 
-        raise exc.BookingNotFoundError(f"Booking for class {class_uuid} not found.")
+        raise exc.ResourceNotFoundError(f"Booking for class {class_uuid} not found.")
 
     def get_class_from_booking(self, booking: models.Booking | models.BookingV2) -> models.OtfClass:
         """Get the class details from a Booking or BookingV2 object.
@@ -368,7 +368,7 @@ class BookingApi:
                 raise exc.AlreadyBookedError(
                     f"Class {class_uuid} is already booked.", booking_uuid=existing_booking.booking_uuid
                 )
-        except exc.BookingNotFoundError:
+        except exc.ResourceNotFoundError:
             pass
 
         if isinstance(otf_class, models.OtfClass):
@@ -420,7 +420,7 @@ class BookingApi:
 
         Raises:
             ValueError: If booking_uuid is None or empty string
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
         """
         if isinstance(booking, models.BookingV2):
             LOGGER.warning("BookingV2 object provided, using the new cancel booking endpoint (`cancel_booking_new`)")
@@ -441,7 +441,7 @@ class BookingApi:
 
         Raises:
             ValueError: If booking_id is None or empty string
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
         """
         if isinstance(booking, models.Booking):
             LOGGER.warning("Booking object provided, using the old cancel booking endpoint (`cancel_booking`)")

--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -88,7 +88,7 @@ class BookingApi:
             if not b.get("id", "").startswith("no-booking-id"):
                 try:
                     results.append(models.BookingV2.create(**b, api=self.otf))
-                except (exc.OtfException, ValueError) as e:
+                except ValueError as e:
                     LOGGER.warning(f"Failed to create BookingV2 from response: {e}. Booking data:\n{b}")
                     continue
 
@@ -216,7 +216,7 @@ class BookingApi:
             c["is_home_studio"] = c["studio"].studio_uuid == self.otf.home_studio_uuid
             try:
                 classes.append(models.OtfClass.create(**c, api=self.otf))
-            except (exc.OtfException, ValueError) as e:
+            except ValueError as e:
                 LOGGER.warning(f"Failed to create OtfClass from response: {e}. Class data:\n{c}")
                 continue
 
@@ -549,7 +549,7 @@ class BookingApi:
         for b in resp:
             try:
                 bookings.append(models.Booking.create(**b, api=self.otf))
-            except (exc.OtfException, ValueError) as e:
+            except ValueError as e:
                 LOGGER.warning(f"Failed to create Booking from response: {e}. Booking data:\n{b}")
                 continue
 

--- a/src/otf_api/api/bookings/booking_client.py
+++ b/src/otf_api/api/bookings/booking_client.py
@@ -51,7 +51,7 @@ class BookingClient:
         Raises:
             AlreadyBookedError: If the class is already booked.
             OutsideSchedulingWindowError: If the class is outside the scheduling window.
-            OtfException: If there is an error booking the class.
+            OtfError: If there is an error booking the class.
         """
         return self.client.default_request("PUT", f"/member/members/{self.member_uuid}/bookings", json=body)["data"]
 

--- a/src/otf_api/api/client.py
+++ b/src/otf_api/api/client.py
@@ -152,7 +152,7 @@ class OtfClient:
 
         if re.match(r"^/member/members/.*?/bookings", path):
             if code == "NOT_AUTHORIZED" and error_msg.startswith("This class booking has been cancelled"):
-                raise exc.BookingNotFoundError("Booking was already cancelled")
+                raise exc.ResourceNotFoundError("Booking was already cancelled")
             if error_code == "603":
                 raise exc.AlreadyBookedError("Class is already booked")
             if error_code == "602":

--- a/src/otf_api/api/studios/studio_api.py
+++ b/src/otf_api/api/studios/studio_api.py
@@ -56,7 +56,15 @@ class StudioApi:
 
         new_faves = resp.get("studios", [])
 
-        return [models.StudioDetail.create(**studio, api=self.otf) for studio in new_faves]
+        studios: list[models.StudioDetail] = []
+        for studio in new_faves:
+            try:
+                studios.append(models.StudioDetail.create(**studio, api=self.otf))
+            except ValueError as e:
+                LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
+                continue
+
+        return studios
 
     def remove_favorite_studio(self, studio_uuids: list[str] | str) -> None:
         """Remove a studio from the member's favorite studios.
@@ -141,7 +149,16 @@ class StudioApi:
         longitude = longitude or self.otf.home_studio.location.longitude
 
         results = self.client.get_studios_by_geo(latitude, longitude, distance)
-        return [models.StudioDetail.create(**studio, api=self.otf) for studio in results]
+
+        studios: list[models.StudioDetail] = []
+        for studio in results:
+            try:
+                studios.append(models.StudioDetail.create(**studio, api=self.otf))
+            except ValueError as e:
+                LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
+                continue
+
+        return studios
 
     def _get_all_studios(self) -> list[models.StudioDetail]:
         """Gets all studios. Marked as private to avoid random users calling it.
@@ -153,7 +170,16 @@ class StudioApi:
         """
         # long/lat being None will cause the endpoint to return all studios
         results = self.client.get_studios_by_geo(None, None)
-        return [models.StudioDetail.create(**studio, api=self.otf) for studio in results]
+
+        studios: list[models.StudioDetail] = []
+        for studio in results:
+            try:
+                studios.append(models.StudioDetail.create(**studio, api=self.otf))
+            except ValueError as e:
+                LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
+                continue
+
+        return studios
 
     def _get_studio_detail_threaded(self, studio_uuids: list[str]) -> dict[str, models.StudioDetail]:
         """Get detailed information about multiple studios in a threaded manner.
@@ -168,7 +194,13 @@ class StudioApi:
             dict[str, StudioDetail]: A dictionary mapping studio UUIDs to their detailed information.
         """
         studio_dicts = self.client.get_studio_detail_threaded(studio_uuids)
-        return {
-            studio_uuid: models.StudioDetail.create(**studio, api=self.otf)
-            for studio_uuid, studio in studio_dicts.items()
-        }
+
+        studios: dict[str, models.StudioDetail] = {}
+        for studio_uuid, studio in studio_dicts.items():
+            try:
+                studios[studio_uuid] = models.StudioDetail.create(**studio, api=self.otf)
+            except ValueError as e:
+                LOGGER.error(f"Failed to create StudioDetail for studio {studio_uuid}: {e}")
+                continue
+
+        return studios

--- a/src/otf_api/api/workouts/workout_api.py
+++ b/src/otf_api/api/workouts/workout_api.py
@@ -270,14 +270,18 @@ class WorkoutApi:
 
         workouts: list[models.Workout] = []
         for perf_id, perf_summary in perf_summaries_dict.items():
-            workout = models.Workout.create(
-                **perf_summary,
-                v2_booking=bookings_dict[perf_id],
-                telemetry=telemetry_dict.get(perf_id),
-                class_uuid=perf_summary_to_class_uuid_map.get(perf_id),
-                api=self.otf,
-            )
-            workouts.append(workout)
+            try:
+                workout = models.Workout.create(
+                    **perf_summary,
+                    v2_booking=bookings_dict[perf_id],
+                    telemetry=telemetry_dict.get(perf_id),
+                    class_uuid=perf_summary_to_class_uuid_map.get(perf_id),
+                    api=self.otf,
+                )
+                workouts.append(workout)
+            except ValueError as e:
+                LOGGER.error(f"Failed to create Workout for performance summary {perf_id}: {e}")
+                continue
 
         return workouts
 

--- a/src/otf_api/api/workouts/workout_api.py
+++ b/src/otf_api/api/workouts/workout_api.py
@@ -221,7 +221,6 @@ class WorkoutApi:
             Workout: The member's workout.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
             ResourceNotFoundError: If the workout does not exist.
             TypeError: If the booking is an old Booking model, as these do not have the necessary fields.
         """

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -4,11 +4,11 @@ if typing.TYPE_CHECKING:
     from httpx import Request, Response
 
 
-class OtfException(Exception):
+class OtfError(Exception):
     """Base class for all exceptions in this package."""
 
 
-class OtfRequestError(OtfException):
+class OtfRequestError(OtfError):
     """Raised when an error occurs while making a request to the OTF API."""
 
     original_exception: Exception | None
@@ -29,7 +29,7 @@ class RetryableOtfRequestError(OtfRequestError):
     """
 
 
-class BookingError(OtfException):
+class BookingError(OtfError):
     """Base class for booking-related errors, with an optional booking UUID attribute."""
 
     booking_uuid: str | None
@@ -53,17 +53,17 @@ class BookingAlreadyCancelledError(BookingError):
     """Raised when attempting to cancel a booking that is already cancelled."""
 
 
-class OutsideSchedulingWindowError(OtfException):
+class OutsideSchedulingWindowError(OtfError):
     """Raised when attempting to book a class outside the scheduling window."""
 
 
-class ResourceNotFoundError(OtfException):
+class ResourceNotFoundError(OtfError):
     """Raised when a resource is not found."""
 
 
-class AlreadyRatedError(OtfException):
+class AlreadyRatedError(OtfError):
     """Raised when attempting to rate a class that is already rated."""
 
 
-class ClassNotRatableError(OtfException):
+class ClassNotRatableError(OtfError):
     """Raised when attempting to rate a class that is not ratable."""

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -57,8 +57,6 @@ class OutsideSchedulingWindowError(OtfException):
     """Raised when attempting to book a class outside the scheduling window."""
 
 
-class BookingNotFoundError(OtfException):
-    """Raised when a booking is not found."""
 
 
 class ResourceNotFoundError(OtfException):

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -57,8 +57,6 @@ class OutsideSchedulingWindowError(OtfException):
     """Raised when attempting to book a class outside the scheduling window."""
 
 
-
-
 class ResourceNotFoundError(OtfException):
     """Raised when a resource is not found."""
 

--- a/src/otf_api/models/bookings/bookings_v2.py
+++ b/src/otf_api/models/bookings/bookings_v2.py
@@ -160,8 +160,8 @@ class BookingV2(ApiMixin, OtfItemBase):
         exclude=True,
         repr=False,
     )
-    updated_at: datetime | None = Field(
-        None, description="Date the booking was updated, not when the booking was made", exclude=True, repr=False
+    updated_at: datetime = Field(
+        description="Date the booking was updated, not when the booking was made", exclude=True, repr=False
     )
 
     @property

--- a/src/otf_api/models/bookings/bookings_v2.py
+++ b/src/otf_api/models/bookings/bookings_v2.py
@@ -160,8 +160,8 @@ class BookingV2(ApiMixin, OtfItemBase):
         exclude=True,
         repr=False,
     )
-    updated_at: datetime = Field(
-        ..., description="Date the booking was updated, not when the booking was made", exclude=True, repr=False
+    updated_at: datetime | None = Field(
+        None, description="Date the booking was updated, not when the booking was made", exclude=True, repr=False
     )
 
     @property

--- a/src/otf_api/models/bookings/bookings_v2.py
+++ b/src/otf_api/models/bookings/bookings_v2.py
@@ -93,7 +93,7 @@ class BookingV2Class(ApiMixin, OtfItemBase):
         """Returns a BookingV2 instance for this class.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If class_uuid is None or empty string or if the API instance is not set.
         """
         self.raise_if_api_not_set()
@@ -107,7 +107,7 @@ class BookingV2Class(ApiMixin, OtfItemBase):
         """Cancels the booking by calling the proper API method.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If class_uuid is None or empty string or if the API instance is not set.
         """
         self.raise_if_api_not_set()

--- a/src/otf_api/models/bookings/classes.py
+++ b/src/otf_api/models/bookings/classes.py
@@ -90,7 +90,7 @@ class OtfClass(ApiMixin, OtfItemBase):
             AlreadyBookedError: If the class is already booked.
             OutsideSchedulingWindowError: If the class is outside the scheduling window.
             ValueError: If class_uuid is None or empty string.
-            OtfException: If there is an error booking the class.
+            OtfError: If there is an error booking the class.
         """
         self.raise_if_api_not_set()
         new_booking = self._api.bookings.book_class(self.class_uuid)

--- a/src/otf_api/models/bookings/classes.py
+++ b/src/otf_api/models/bookings/classes.py
@@ -18,7 +18,7 @@ class OtfClass(ApiMixin, OtfItemBase):
     class_uuid: str = Field(validation_alias="ot_base_class_uuid", description="The OTF class UUID")
     class_id: str | None = Field(None, validation_alias="id", description="Matches new booking endpoint class id")
 
-    name: str | None = Field(None, description="The name of the class")
+    name: str = Field(..., description="The name of the class")
     class_type: ClassType = Field(validation_alias="type")
     coach: str | None = Field(None, validation_alias=AliasPath("coach", "first_name"))
     ends_at: datetime = Field(
@@ -101,7 +101,7 @@ class OtfClass(ApiMixin, OtfItemBase):
         """Cancels the class booking.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If booking_uuid is None or empty string or the API is not set.
         """
         self.raise_if_api_not_set()
@@ -114,11 +114,11 @@ class OtfClass(ApiMixin, OtfItemBase):
             Booking | BookingV2: The booking associated with this class.
 
         Raises:
-            BookingNotFoundError: If the booking does not exist.
+            ResourceNotFoundError: If the booking does not exist.
             ValueError: If the API is not set.
         """
         self.raise_if_api_not_set()
         try:
             return self._api.bookings.get_booking_from_class(self)
-        except exc.BookingNotFoundError:
+        except exc.ResourceNotFoundError:
             return self._api.bookings.get_booking_from_class_new(self)


### PR DESCRIPTION
- add `get_class_from_booking` (supports new and old) and `get_class_from_booking_new` (supports new) methods
- make `name` attribute of `OtfClass` required
- separate out deduplicate logic
- filter out weird non-booking bookings - records with a limited payload with ids like 'no-booking-id-<GUID>'
- catch validation errors when creating model instances in a loop
- rename OtfException to OtfError