### PR TITLE
Fix/telemtry zones optional

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.15.0"
+current_version = "0.15.1"
 
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(?:-(?P<rc_l>rc)(?P<rc>0|[1-9]\\d*))?"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "otf-api"
-version = "0.15.0"
+version = "0.15.1"
 description = "Python OrangeTheory Fitness API Client"
 authors = [{ name = "Jessica Smith", email = "j.smith.git1@gmail.com" }]
 requires-python = ">=3.11"

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../src"))  # type: ignore # noqa
 project = "OrangeTheory API"
 copyright = "2025, Jessica Smith"
 author = "Jessica Smith"
-release = "0.15.0"
+release = "0.15.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/src/otf_api/__init__.py
+++ b/src/otf_api/__init__.py
@@ -36,7 +36,7 @@ def _setup_logging() -> None:
 
 _setup_logging()
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 
 __all__ = ["Otf", "OtfUser", "models"]

--- a/src/otf_api/models/workouts/telemetry.py
+++ b/src/otf_api/models/workouts/telemetry.py
@@ -59,16 +59,17 @@ class Telemetry(OtfItemBase):
     )
     class_start_time: datetime | None = Field(None, validation_alias="classStartTime")
     max_hr: int | None = Field(None, validation_alias="maxHr")
-    zones: Zones
+    zones: Zones | None = Field(default=None, description="The zones associated with the telemetry.")
     window_size: int | None = Field(None, validation_alias="windowSize")
     telemetry: list[TelemetryItem] = Field(default_factory=list)
 
     def __init__(self, **data: dict[str, Any]):
         super().__init__(**data)
-        for telem in self.telemetry:
-            if self.class_start_time is None:
-                continue
 
+        if self.class_start_time is None:
+            return
+
+        for telem in self.telemetry:
             telem.timestamp = self.class_start_time + timedelta(seconds=telem.relative_timestamp)
 
     @field_serializer("telemetry", when_used="json")

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "otf-api"
-version = "0.14.1"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
- make `zones` optional on `Telemetry`
- check `self.class_start_time is None` one time and return if it's None, instead of checking every single loop iteration