### PR TITLE
Generate OpenAPI schema definition files for allowing downstream library generation

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -8,9 +8,11 @@ on:
 
 jobs:
   build-pypi-dists:
-    name: Build Python package
+    name: Build Python package & OpenAPI schema
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -48,11 +50,44 @@ jobs:
           name: pypi-dists
           path: "./dist"
 
-      - name: Publish schema artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: openapi-schema
-          path: "./schema"
+      - name: Create release and upload schema
+        run: |
+          echo "Checking for release: ${{ github.ref_name }}"
+          
+          # Check if release exists with better error handling
+          if gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} >/dev/null 2>&1; then
+            echo "Release exists, getting details..."
+            RELEASE_INFO=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }})
+            echo "Release info: $RELEASE_INFO"
+          else
+            echo "Release not found via API, but it might exist. Creating anyway..."
+            gh api --method POST repos/${{ github.repository }}/releases \
+              --field tag_name=${{ github.ref_name }} \
+              --field name="${{ github.ref_name }}" \
+              --field body="Release for ${{ github.ref_name }}"
+          fi
+          
+          # Get the release upload URL
+          echo "Getting release upload URL..."
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq '.id')
+          echo "Release ID: $RELEASE_ID"
+          UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/$RELEASE_ID --jq '.upload_url' | sed 's/{?name,label}//')
+          echo "Upload URL: $UPLOAD_URL"
+          
+          echo "Uploading schema files to release..."
+          
+          # Upload both files
+          gh api --method POST "$UPLOAD_URL?name=openapi.yaml" \
+            --header "Content-Type: application/x-yaml" \
+            --input ./schema/openapi.yaml
+          
+          gh api --method POST "$UPLOAD_URL?name=openapi.json" \
+            --header "Content-Type: application/json" \
+            --input ./schema/openapi.json
+          
+          echo "Schema files uploaded successfully!"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
   publish-pypi-dists:
     name: Publish to PyPI

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Create release and upload schema
         run: |
           echo "Checking for release: ${{ github.ref_name }}"
-          
+
           # Check if release exists with better error handling
           if gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} >/dev/null 2>&1; then
             echo "Release exists, getting details..."
@@ -66,25 +66,25 @@ jobs:
               --field name="${{ github.ref_name }}" \
               --field body="Release for ${{ github.ref_name }}"
           fi
-          
+
           # Get the release upload URL
           echo "Getting release upload URL..."
           RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq '.id')
           echo "Release ID: $RELEASE_ID"
           UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/$RELEASE_ID --jq '.upload_url' | sed 's/{?name,label}//')
           echo "Upload URL: $UPLOAD_URL"
-          
+
           echo "Uploading schema files to release..."
-          
+
           # Upload both files
           gh api --method POST "$UPLOAD_URL?name=openapi.yaml" \
             --header "Content-Type: application/x-yaml" \
             --input ./schema/openapi.yaml
-          
+
           gh api --method POST "$UPLOAD_URL?name=openapi.json" \
             --header "Content-Type: application/json" \
             --input ./schema/openapi.json
-          
+
           echo "Schema files uploaded successfully!"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -39,11 +39,20 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: uv build
 
+      - name: Generate OpenAPI schema
+        run: uv run python scripts/generate_openapi.py
+
       - name: Publish build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: pypi-dists
           path: "./dist"
+
+      - name: Publish schema artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-schema
+          path: "./schema"
 
   publish-pypi-dists:
     name: Publish to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Generated schema shouldn't be checked in
+schema/
+
 # C extensions
 *.so
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,49 @@ otf = Otf()
 otf = Otf(user=OtfUser(<email_address>,<password>))
 
 ```
+
+## OpenAPI Schema
+
+This library generates OpenAPI 3.0.3 schema files from its Pydantic models, providing a machine-readable representation of the API structure and data models. These schemas are automatically generated during the build process and are available as build artifacts.
+
+### What's Generated
+
+The OpenAPI schema includes:
+- All public Pydantic models from the `otf_api.models` module
+- Complete type definitions with field descriptions and constraints
+- Nested model references and relationships
+- Both YAML (`openapi.yaml`) and JSON (`openapi.json`) formats
+
+### Why It's Generated
+
+The OpenAPI schema serves as a contract for other language implementations and tools:
+- **TypeScript Implementation**: Used by [mphuff/otf-api-ts](https://github.com/mphuff/otf-api-ts) to generate type-safe TypeScript clients
+- **API Documentation**: Provides machine-readable API documentation
+- **Code Generation**: Enables automatic code generation for other programming languages
+- **Integration Tools**: Supports IDE integrations and API testing tools
+
+### Generating the Schema
+
+To generate the OpenAPI schema locally:
+
+```bash
+# Install dependencies
+uv sync
+
+# Generate schema
+uv run python scripts/generate_openapi.py
+```
+
+The schema files will be created in the `schema/` directory:
+- `schema/openapi.yaml` - YAML format (recommended for readability)
+- `schema/openapi.json` - JSON format (recommended for tooling)
+
+### Schema Structure
+
+The generated schema follows OpenAPI 3.0.3 specification with:
+- **Info**: API metadata and version information
+- **Components/Schemas**: All Pydantic models as reusable schema definitions
+- **Field Names**: Uses snake_case field names to match Python usage
+- **Type References**: Properly resolved nested model references
+
+The schema represents the complete structure of public API objects documented in the user documentation, making it easy to build compatible clients in other languages.

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate OpenAPI schema from Pydantic models for TypeScript consumption."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Type
+import inspect
+
+import yaml
+from pydantic import BaseModel
+
+# Add src to path so we can import otf_api modules
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import otf_api.models as models
+
+
+def get_all_pydantic_models() -> Dict[str, Type[BaseModel]]:
+    """Discover all Pydantic models from otf_api.models.__all__."""
+    pydantic_models = {}
+    
+    # Get all exported items from models module
+    for name in models.__all__:
+        try:
+            obj = getattr(models, name)
+            # Check if it's a Pydantic model (class that inherits from BaseModel)
+            if (inspect.isclass(obj) and 
+                issubclass(obj, BaseModel) and 
+                obj is not BaseModel):
+                pydantic_models[name] = obj
+        except (AttributeError, TypeError):
+            # Skip non-model items like functions, constants, etc.
+            continue
+    
+    return pydantic_models
+
+
+def generate_openapi_schema() -> Dict[str, Any]:
+    """Generate complete OpenAPI schema from all discovered models."""
+    
+    # Discover all Pydantic models automatically
+    models_dict = get_all_pydantic_models()
+    
+    print(f"Found {len(models_dict)} Pydantic models:")
+    for name in sorted(models_dict.keys()):
+        print(f"  - {name}")
+    
+    # Generate a combined schema with all models
+    all_schemas = []
+    for model in models_dict.values():
+        all_schemas.append(model)
+    
+    # Use Pydantic's built-in schema generation for all models at once
+    from pydantic import TypeAdapter
+    
+    # Create a union of all models to generate a complete schema
+    combined_schema = {}
+    all_definitions = {}
+    
+    for name, model in models_dict.items():
+        try:
+            # Generate schema using model field names (not aliases)
+            # This ensures we get snake_case field names that match Python usage
+            schema = model.model_json_schema(by_alias=False)
+            
+            # Process the main schema
+            main_schema = {k: v for k, v in schema.items() if k != "$defs"}
+            combined_schema[name] = main_schema
+            
+            # Collect all $defs from all schemas
+            if "$defs" in schema:
+                for def_name, def_value in schema["$defs"].items():
+                    # Flatten nested $defs recursively
+                    _flatten_defs(def_value, all_definitions)
+                    all_definitions[def_name] = def_value
+                    
+        except Exception as e:
+            print(f"Warning: Could not generate schema for {name}: {e}")
+            continue
+    
+    # Update all references to use components/schemas
+    _update_all_refs(combined_schema)
+    _update_all_refs(all_definitions)
+    
+    # Merge all schemas
+    final_schemas = {**combined_schema, **all_definitions}
+    
+    # Create OpenAPI document structure
+    openapi_doc = {
+        "openapi": "3.0.3",
+        "info": {
+            "title": "OTF API Models",
+            "version": getattr(models, "__version__", "1.0.0"),
+            "description": "Generated TypeScript models from Python Pydantic models",
+        },
+        "components": {
+            "schemas": final_schemas
+        }
+    }
+    
+    return openapi_doc
+
+
+def _flatten_defs(schema: Dict[str, Any], all_definitions: Dict[str, Any]) -> None:
+    """Recursively flatten nested $defs."""
+    if isinstance(schema, dict) and "$defs" in schema:
+        for def_name, def_value in schema["$defs"].items():
+            _flatten_defs(def_value, all_definitions)
+            all_definitions[def_name] = def_value
+        # Remove nested $defs after flattening
+        del schema["$defs"]
+
+
+def _update_all_refs(obj: Any) -> None:
+    """Recursively update all $ref paths to use components/schemas format."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key == "$ref" and isinstance(value, str):
+                if value.startswith("#/$defs/"):
+                    def_name = value.replace("#/$defs/", "")
+                    obj[key] = f"#/components/schemas/{def_name}"
+            else:
+                _update_all_refs(value)
+    elif isinstance(obj, list):
+        for item in obj:
+            _update_all_refs(item)
+
+
+def main():
+    """Generate and save OpenAPI schema."""
+    try:
+        schema = generate_openapi_schema()
+        
+        # Create schema directory
+        schema_dir = Path(__file__).parent.parent / "schema"
+        schema_dir.mkdir(exist_ok=True)
+        
+        # Write YAML file
+        yaml_file = schema_dir / "openapi.yaml"
+        with open(yaml_file, "w") as f:
+            yaml.dump(schema, f, default_flow_style=False, sort_keys=False)
+        
+        # Also write JSON file for backup
+        json_file = schema_dir / "openapi.json"
+        with open(json_file, "w") as f:
+            json.dump(schema, f, indent=2)
+        
+        print(f"\n✅ Generated OpenAPI schema:")
+        print(f"   YAML: {yaml_file}")
+        print(f"   JSON: {json_file}")
+        print(f"   Models: {len(schema['components']['schemas'])}")
+        
+    except Exception as e:
+        print(f"❌ Error generating schema: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Changes included in this PR:
- New script in `scripts/` that generates an openapi-compatible schema
- Update to the python publishing action that now also publishes generated schema files to the release with the tag name
- Update to README to note about this new capability and option for this library
