### PR TITLE
feat: add diagnostic logging for silent failures and empty API responses

### DIFF
--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -125,6 +125,10 @@ class BookingApi:
                 )
                 continue
 
+        dropped = len(bookings_resp) - len(results)
+        if dropped:
+            LOGGER.warning("Dropped %d of %d bookings due to parsing errors", dropped, len(bookings_resp))
+
         if not remove_duplicates:
             return results
 
@@ -249,6 +253,10 @@ class BookingApi:
             except ValueError as e:
                 LOGGER.warning(f"Failed to create OtfClass from response: {e}. Class data:\n{c}")
                 continue
+
+        dropped_classes = len(classes_resp) - len(classes)
+        if dropped_classes:
+            LOGGER.warning("Dropped %d of %d classes due to parsing errors", dropped_classes, len(classes_resp))
 
         # additional data filtering and enrichment
 
@@ -582,6 +590,10 @@ class BookingApi:
             except ValueError as e:
                 LOGGER.warning(f"Failed to create Booking from response: {e}. Booking data:\n{b}")
                 continue
+
+        dropped_bookings = len(resp) - len(bookings)
+        if dropped_bookings:
+            LOGGER.warning("Dropped %d of %d bookings due to parsing errors", dropped_bookings, len(resp))
 
         bookings = sorted(bookings, key=lambda x: x.otf_class.starts_at)
 

--- a/src/otf_api/api/studios/studio_api.py
+++ b/src/otf_api/api/studios/studio_api.py
@@ -44,6 +44,10 @@ class StudioApi:
                 LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
                 continue
 
+        dropped = len(results) - len(studios)
+        if dropped:
+            LOGGER.warning("Dropped %d of %d studios due to parsing errors", dropped, len(results))
+
         return studios
 
     def _get_studio_detail_threaded(self, studio_uuids: list[str]) -> dict[str, models.StudioDetail]:
@@ -67,6 +71,10 @@ class StudioApi:
             except ValueError as e:
                 LOGGER.error(f"Failed to create StudioDetail for studio {studio_uuid}: {e}")
                 continue
+
+        dropped = len(studio_dicts) - len(studios)
+        if dropped:
+            LOGGER.warning("Dropped %d of %d studios due to parsing errors", dropped, len(studio_dicts))
 
         return studios
 
@@ -108,6 +116,10 @@ class StudioApi:
             except ValueError as e:
                 LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
                 continue
+
+        dropped = len(new_faves) - len(studios)
+        if dropped:
+            LOGGER.warning("Dropped %d of %d studios due to parsing errors", dropped, len(new_faves))
 
         return studios
 
@@ -167,6 +179,7 @@ class StudioApi:
         try:
             res = self.client.get_studio_detail(studio_uuid)
         except exc.ResourceNotFoundError:
+            LOGGER.warning("Studio %s not found, using empty placeholder. Downstream data may be incomplete.", studio_uuid)
             return models.StudioDetail.create_empty_model(studio_uuid)
 
         return models.StudioDetail.create(**res, api=self.otf)
@@ -202,5 +215,9 @@ class StudioApi:
             except ValueError as e:
                 LOGGER.error(f"Failed to create StudioDetail for studio {studio}: {e}")
                 continue
+
+        dropped = len(results) - len(studios)
+        if dropped:
+            LOGGER.warning("Dropped %d of %d studios due to parsing errors", dropped, len(results))
 
         return studios

--- a/src/otf_api/api/studios/studio_api.py
+++ b/src/otf_api/api/studios/studio_api.py
@@ -179,7 +179,10 @@ class StudioApi:
         try:
             res = self.client.get_studio_detail(studio_uuid)
         except exc.ResourceNotFoundError:
-            LOGGER.warning("Studio %s not found, using empty placeholder. Downstream data may be incomplete.", studio_uuid)
+            LOGGER.warning(
+                "Studio %s not found, using empty placeholder. Downstream data may be incomplete.",
+                studio_uuid,
+            )
             return models.StudioDetail.create_empty_model(studio_uuid)
 
         return models.StudioDetail.create(**res, api=self.otf)

--- a/src/otf_api/api/workouts/workout_api.py
+++ b/src/otf_api/api/workouts/workout_api.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from typing import Any, Literal
 
 import pendulum
+from pydantic import ValidationError
 
 from otf_api import exceptions as exc
 from otf_api import models
@@ -274,15 +275,34 @@ class WorkoutApi:
         for booking, perf_summary_id in bookings_list:
             try:
                 perf_summary = perf_summaries_dict.get(perf_summary_id, {}) if perf_summary_id else {}
+                if perf_summary_id and not perf_summary:
+                    LOGGER.warning(
+                        "No performance summary data found for %s — workout will have limited data",
+                        perf_summary_id,
+                    )
                 telemetry = telemetry_dict.get(perf_summary_id, None) if perf_summary_id else None
                 class_uuid = perf_summary_to_class_uuid_map.get(perf_summary_id, None) if perf_summary_id else None
                 workout = models.Workout.create(
                     **perf_summary, v2_booking=booking, telemetry=telemetry, class_uuid=class_uuid, api=self.otf
                 )
                 workouts.append(workout)
+            except ValidationError:
+                LOGGER.exception(
+                    "Failed to parse workout data for performance summary %s — the OTF API response "
+                    "may have changed. Please open an issue at https://github.com/NodeJSmith/otf-api/issues",
+                    perf_summary_id,
+                )
             except ValueError:
                 LOGGER.exception("Failed to create Workout for performance summary %s", perf_summary_id)
 
+        dropped = len(bookings_list) - len(workouts)
+        if dropped:
+            LOGGER.warning(
+                "Returned %d of %d workouts (%d failed to parse)",
+                len(workouts),
+                len(bookings_list),
+                dropped,
+            )
         LOGGER.debug("Returning %d workouts", len(workouts))
 
         return workouts

--- a/src/otf_api/api/workouts/workout_client.py
+++ b/src/otf_api/api/workouts/workout_client.py
@@ -141,7 +141,11 @@ class WorkoutClient:
                         e,
                     )
 
-        LOGGER.debug("Retrieved %d of %d performance summaries in threaded mode", len(perf_summaries_dict), len(performance_summary_ids))
+        LOGGER.debug(
+            "Retrieved %d of %d performance summaries in threaded mode",
+            len(perf_summaries_dict),
+            len(performance_summary_ids),
+        )
 
         return perf_summaries_dict
 
@@ -173,7 +177,11 @@ class WorkoutClient:
                         e,
                     )
 
-        LOGGER.debug("Retrieved %d of %d telemetry records in threaded mode", len(telemetry_dict), len(performance_summary_ids))
+        LOGGER.debug(
+            "Retrieved %d of %d telemetry records in threaded mode",
+            len(telemetry_dict),
+            len(performance_summary_ids),
+        )
 
         return telemetry_dict
 

--- a/src/otf_api/api/workouts/workout_client.py
+++ b/src/otf_api/api/workouts/workout_client.py
@@ -159,7 +159,7 @@ class WorkoutClient:
             max_data_points (int): The max data points to use for the telemetry. Default is 150.
 
         Returns:
-            dict[str, Telemetry]: A dictionary of telemetry, keyed by performance summary ID.
+            dict[str, dict[str, Any]]: A dictionary of telemetry, keyed by performance summary ID.
         """
         partial_fn = partial(self.get_telemetry, max_data_points=max_data_points)
         telemetry_dict: dict[str, dict[str, Any]] = {}

--- a/src/otf_api/api/workouts/workout_client.py
+++ b/src/otf_api/api/workouts/workout_client.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
 from logging import getLogger
 from typing import Any
@@ -60,11 +60,20 @@ class WorkoutClient:
     @CACHE.memoize(expire=600, tag="telemetry")
     def get_telemetry(self, performance_summary_id: str, max_data_points: int = 150) -> dict:
         """Retrieve raw telemetry data."""
-        return self.telemetry_request(
+        data = self.telemetry_request(
             "GET",
             "/v1/performance/summary",
             params={"classHistoryUuid": performance_summary_id, "maxDataPoints": max_data_points},
         )
+
+        if not data.get("telemetry"):
+            LOGGER.warning(
+                "Telemetry response for performance_summary_id=%s has no telemetry data. "
+                "This usually means the heart rate monitor was not connected during the workout.",
+                performance_summary_id,
+            )
+
+        return data
 
     def get_body_composition_list(self) -> dict:
         """Retrieve raw body composition list."""
@@ -117,15 +126,22 @@ class WorkoutClient:
         Returns:
             dict[str, dict[str, Any]]: A dictionary of performance summaries, keyed by performance summary ID.
         """
+        perf_summaries_dict: dict[str, dict[str, Any]] = {}
         with ThreadPoolExecutor(max_workers=10) as pool:
-            perf_summaries = pool.map(self.get_performance_summary, performance_summary_ids)
+            futures = {pool.submit(self.get_performance_summary, psid): psid for psid in performance_summary_ids}
+            for future in as_completed(futures):
+                psid = futures[future]
+                try:
+                    result = future.result()
+                    perf_summaries_dict[result["id"]] = result
+                except Exception as e:
+                    LOGGER.warning(
+                        "Failed to retrieve performance summary %s — this workout will be excluded: %s",
+                        psid,
+                        e,
+                    )
 
-        perf_summaries_list = list(perf_summaries)
-        LOGGER.debug("Retrieved %d performance summaries in threaded mode", len(perf_summaries_list))
-
-        perf_summaries_dict = {perf_summary["id"]: perf_summary for perf_summary in perf_summaries_list}
-
-        LOGGER.debug("Returning %d performance summaries", len(perf_summaries_dict))
+        LOGGER.debug("Retrieved %d of %d performance summaries in threaded mode", len(perf_summaries_dict), len(performance_summary_ids))
 
         return perf_summaries_dict
 
@@ -142,16 +158,22 @@ class WorkoutClient:
             dict[str, Telemetry]: A dictionary of telemetry, keyed by performance summary ID.
         """
         partial_fn = partial(self.get_telemetry, max_data_points=max_data_points)
+        telemetry_dict: dict[str, dict[str, Any]] = {}
         with ThreadPoolExecutor(max_workers=10) as pool:
-            telemetry = pool.map(partial_fn, performance_summary_ids)
+            futures = {pool.submit(partial_fn, psid): psid for psid in performance_summary_ids}
+            for future in as_completed(futures):
+                psid = futures[future]
+                try:
+                    result = future.result()
+                    telemetry_dict[result["classHistoryUuid"]] = result
+                except Exception as e:
+                    LOGGER.warning(
+                        "Failed to retrieve telemetry for performance summary %s — heart rate data will be missing: %s",
+                        psid,
+                        e,
+                    )
 
-        telemetry_list = list(telemetry)
-
-        LOGGER.debug("Retrieved %d telemetry records in threaded mode", len(telemetry_list))
-
-        telemetry_dict = {perf_summary["classHistoryUuid"]: perf_summary for perf_summary in telemetry_list}
-
-        LOGGER.debug("Returning %d telemetry records", len(telemetry_dict))
+        LOGGER.debug("Retrieved %d of %d telemetry records in threaded mode", len(telemetry_dict), len(performance_summary_ids))
 
         return telemetry_dict
 

--- a/src/otf_api/auth/auth.py
+++ b/src/otf_api/auth/auth.py
@@ -266,6 +266,7 @@ class OtfCognito(Cognito):
             CACHE.write_device_data_to_cache(self.device_metadata)
         except Exception:
             LOGGER.exception("Failed to write device key cache")
+            LOGGER.warning("Device key was not persisted — next login may require full re-authentication")
 
     ##### OVERRIDDEN METHODS #####
 

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -16,7 +16,7 @@ def _log_initial_auth_error(e: ClientError, username: str | None) -> None:
     elif code == "UserNotFoundException":
         LOGGER.warning("Authentication failed — no account found for %s", username)
     else:
-        LOGGER.error("Failed to authenticate with Cognito", exc_info=e)
+        LOGGER.exception("Failed to authenticate with Cognito")
 
 
 @attrs.define(init=False)

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -1,6 +1,7 @@
 from logging import getLogger
 
 import attrs
+from botocore.exceptions import ClientError
 
 from otf_api.auth.auth import HttpxCognitoAuth, NoCredentialsError, OtfCognito
 from otf_api.auth.utils import get_username_password
@@ -50,6 +51,15 @@ class OtfUser:
             LOGGER.debug("No credentials provided, attempting to get them from environment or prompt user")
             username, password = get_username_password()
             self.cognito = OtfCognito(username=username, password=password)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code == "NotAuthorizedException":
+                LOGGER.warning("Authentication failed — incorrect password for %s", username)
+            elif code == "UserNotFoundException":
+                LOGGER.warning("Authentication failed — no account found for %s", username)
+            else:
+                LOGGER.exception("Failed to authenticate with Cognito")
+            raise
         except Exception:
             LOGGER.exception("Failed to authenticate with Cognito")
             raise

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -9,6 +9,16 @@ from otf_api.auth.utils import get_username_password
 LOGGER = getLogger(__name__)
 
 
+def _log_initial_auth_error(e: ClientError, username: str | None) -> None:
+    code = e.response.get("Error", {}).get("Code", "")
+    if code == "NotAuthorizedException":
+        LOGGER.warning("Authentication failed — incorrect password for %s", username)
+    elif code == "UserNotFoundException":
+        LOGGER.warning("Authentication failed — no account found for %s", username)
+    else:
+        LOGGER.error("Failed to authenticate with Cognito", exc_info=e)
+
+
 @attrs.define(init=False)
 class OtfUser:
     """OtfUser is a thin wrapper around OtfCognito, meant to hide all of the gory details from end users."""
@@ -50,15 +60,16 @@ class OtfUser:
         except NoCredentialsError:
             LOGGER.debug("No credentials provided, attempting to get them from environment or prompt user")
             username, password = get_username_password()
-            self.cognito = OtfCognito(username=username, password=password)
-        except ClientError as e:
-            code = e.response.get("Error", {}).get("Code", "")
-            if code == "NotAuthorizedException":
-                LOGGER.warning("Authentication failed — incorrect password for %s", username)
-            elif code == "UserNotFoundException":
-                LOGGER.warning("Authentication failed — no account found for %s", username)
-            else:
+            try:
+                self.cognito = OtfCognito(username=username, password=password)
+            except ClientError as e:
+                _log_initial_auth_error(e, username)
+                raise
+            except Exception:
                 LOGGER.exception("Failed to authenticate with Cognito")
+                raise
+        except ClientError as e:
+            _log_initial_auth_error(e, username)
             raise
         except Exception:
             LOGGER.exception("Failed to authenticate with Cognito")

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "otf-api"
-version = "0.15.4"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Adds WARNING-level logging throughout the codebase so users can understand why data is missing without digging into source code.

## Changes

- **Telemetry**: Log when the API returns empty telemetry data (usually means HR monitor wasn't connected)
- **Threaded fetches**: Replaced `pool.map()` with per-item futures so a single failure doesn't crash the entire batch — logs which specific IDs failed and returns partial results
- **Bookings/Studios/Workouts**: Log count of dropped items after parse loops so users know they're getting incomplete results
- **Workout creation**: Catch `ValidationError` separately with an actionable message pointing to GitHub issues
- **Studios**: Log when an empty placeholder model is used on 404
- **Auth**: Distinguish bad password vs unknown email on Cognito failures; warn about consequence of device key cache write failure

## Motivation

Users report empty telemetry for some workouts (see #118 discussion). Investigation confirmed this is server-side (OTF simply doesn't return telemetry for certain workouts), but the library gave no indication of what was happening. These changes make all silent failures observable via standard Python logging.

## Testing

All 189 tests pass, 9 skipped (anonymize integration tests that require local raw fixtures).