### PR TITLE
fix: cancel_booking crash on BookingV2 and missing class_uuid in get_workout_from_booking

### DIFF
--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -493,6 +493,7 @@ class BookingApi:
         if isinstance(booking, models.BookingV2):
             LOGGER.warning("BookingV2 object provided, using the new cancel booking endpoint (`cancel_booking_new`)")
             self.cancel_booking_new(booking)
+            return
 
         booking_uuid = utils.get_booking_uuid(booking)
 
@@ -514,6 +515,7 @@ class BookingApi:
         if isinstance(booking, models.Booking):
             LOGGER.warning("Booking object provided, using the old cancel booking endpoint (`cancel_booking`)")
             self.cancel_booking(booking)
+            return
 
         booking_id = utils.get_booking_id(booking)
 

--- a/src/otf_api/api/bookings/booking_api.py
+++ b/src/otf_api/api/bookings/booking_api.py
@@ -480,11 +480,11 @@ class BookingApi:
 
         return new_booking
 
-    def cancel_booking(self, booking: str | models.Booking) -> None:
+    def cancel_booking(self, booking: str | models.Booking | models.BookingV2) -> None:
         """Cancel a booking by providing either the booking_uuid or the Booking object.
 
         Args:
-            booking (str | Booking): The booking UUID or the Booking object to cancel.
+            booking (str | Booking | BookingV2): The booking UUID or the Booking/BookingV2 object to cancel.
 
         Raises:
             ValueError: If booking_uuid is None or empty string
@@ -502,11 +502,11 @@ class BookingApi:
 
         self.client.delete_booking(booking_uuid)
 
-    def cancel_booking_new(self, booking: str | models.BookingV2) -> None:
+    def cancel_booking_new(self, booking: str | models.Booking | models.BookingV2) -> None:
         """Cancel a booking by providing either the booking_id or the BookingV2 object.
 
         Args:
-            booking (str | BookingV2): The booking ID or the BookingV2 object to cancel.
+            booking (str | Booking | BookingV2): The booking ID or the Booking/BookingV2 object to cancel.
 
         Raises:
             ValueError: If booking_id is None or empty string

--- a/src/otf_api/api/workouts/workout_api.py
+++ b/src/otf_api/api/workouts/workout_api.py
@@ -237,7 +237,10 @@ class WorkoutApi:
 
         perf_summary = self.client.get_performance_summary(booking.workout.performance_summary_id)
         telemetry = self.get_telemetry(booking.workout.performance_summary_id)
-        workout = models.Workout.create(**perf_summary, v2_booking=booking, telemetry=telemetry, api=self.otf)
+        class_uuid = booking.otf_class.class_uuid
+        workout = models.Workout.create(
+            **perf_summary, v2_booking=booking, telemetry=telemetry, class_uuid=class_uuid, api=self.otf
+        )
 
         return workout
 

--- a/tests/test_api/test_bug_fixes.py
+++ b/tests/test_api/test_bug_fixes.py
@@ -1,0 +1,62 @@
+"""Tests for bug fixes #121 and #122."""
+
+from datetime import date
+from unittest.mock import patch
+
+import httpx
+from conftest import MOCK_MEMBER_UUID
+
+from otf_api.models.bookings import Booking, BookingV2
+
+
+class TestCancelBookingCrossDispatch:
+    """Bug #121: cancel methods missing return after cross-dispatch."""
+
+    def test_cancel_booking_with_v2_does_not_fall_through(self, mock_otf, mock_router) -> None:
+        """cancel_booking(BookingV2) should dispatch to cancel_booking_new and return."""
+        bookings = mock_otf.bookings.get_bookings_new(
+            start_date=date(2026, 3, 27), end_date=date(2026, 4, 26)
+        )
+        booking_v2 = bookings[0]
+        assert isinstance(booking_v2, BookingV2)
+
+        delete_url = f"https://api.orangetheory.io/v1/bookings/me/{booking_v2.booking_id}"
+        delete_route = mock_router.request("DELETE", delete_url).mock(return_value=httpx.Response(200, json={}))
+
+        mock_otf.bookings.cancel_booking(booking_v2)
+
+        assert delete_route.called
+
+    def test_cancel_booking_new_with_v1_does_not_fall_through(self, mock_otf, mock_router) -> None:
+        """cancel_booking_new(Booking) should dispatch to cancel_booking and return."""
+        bookings = mock_otf.bookings.get_bookings(exclude_cancelled=False, exclude_checkedin=False)
+        booking_v1 = bookings[0]
+        assert isinstance(booking_v1, Booking)
+
+        delete_url = (
+            f"https://api.orangetheory.co/member/members/{MOCK_MEMBER_UUID}"
+            f"/bookings/{booking_v1.booking_uuid}?confirmed=true"
+        )
+        delete_route = mock_router.request("DELETE", delete_url).mock(return_value=httpx.Response(200, json={}))
+
+        mock_otf.bookings.cancel_booking_new(booking_v1)
+
+        assert delete_route.called
+
+
+class TestGetWorkoutFromBookingClassUuid:
+    """Bug #122: get_workout_from_booking produces workouts with class_uuid=None."""
+
+    def test_workout_from_booking_has_class_uuid(self, mock_otf) -> None:
+        """Workouts from get_workout_from_booking should have class_uuid populated."""
+        bookings = mock_otf.bookings.get_bookings_new(
+            start_date=date(2026, 3, 27), end_date=date(2026, 4, 26)
+        )
+        booking_with_workout = next(b for b in bookings if b.workout and b.workout.performance_summary_id)
+        expected_class_uuid = booking_with_workout.otf_class.class_uuid
+        assert expected_class_uuid is not None
+
+        with patch.object(mock_otf.bookings, "get_booking_new", return_value=booking_with_workout):
+            workout = mock_otf.workouts.get_workout_from_booking(booking_with_workout)
+
+        assert workout.class_uuid == expected_class_uuid


### PR DESCRIPTION
## Summary

Fixes two bugs found via decompiled APK audit.

### cancel_booking() crash on BookingV2 (#121)

`cancel_booking()` dispatched to `cancel_booking_new()` for `BookingV2` objects but was missing a `return`, so execution fell through and crashed on `get_booking_uuid()` which doesn't handle `BookingV2`. Same pattern in reverse for `cancel_booking_new()` receiving a `Booking` object.

**Fix:** Added `return` after both cross-dispatch calls.

### get_workout_from_booking() non-ratable workouts (#122)

`get_workout_from_booking()` didn't extract `class_uuid` from the performance summary response, so workouts fetched this way always had `class_uuid=None`. Any attempt to rate them would raise `ClassNotRatableError`.

**Fix:** Extract `ot_base_class_uuid` from the perf summary's `class` dict and pass it to `Workout.create()`, matching how `get_workouts()` already does it.

## Closes

- Closes #121
- Closes #122