### PR TITLE
feat(bookings): detect waitlisted V2 bookings via waitlist_position field

### DIFF
--- a/fixtures/anonymized/bookings/get_bookings_new__2026-03-27.json
+++ b/fixtures/anonymized/bookings/get_bookings_new__2026-03-27.json
@@ -371,6 +371,54 @@
           "image_url": "https://placeholder.example.com/profile/712936.jpg"
         }
       }
+    },
+    {
+      "id": "a1e2f3d4-5678-4abc-9def-0123456789ab",
+      "paying_studio_id": "452ec40a-3193-4a54-ae89-71105e503a67",
+      "person_id": "35f724cc-595b-4045-8219-9445a74c0c5b",
+      "member_id": "d1f6f86c-029a-4245-bb91-433a6aa79987",
+      "service_name": "Orange Premier Membership",
+      "checked_in": false,
+      "cross_regional": false,
+      "late_canceled": false,
+      "intro": false,
+      "mbo_booking_id": "892145673",
+      "mbo_unique_id": "518304835",
+      "mbo_paying_unique_id": "518304835",
+      "canceled": false,
+      "created_at": "2026-04-05T14:30:00.000Z",
+      "updated_at": "2026-04-05T14:30:00.000Z",
+      "ratable": false,
+      "waitlist_position": 3,
+      "class": {
+        "id": "f9e8d7c6-b5a4-4321-fedc-ba9876543210",
+        "name": "Orange 60",
+        "type": "ORANGE_60",
+        "starts_at_local": "2026-04-08T17:00:00",
+        "starts_at": "2026-04-08T22:00:00.000Z",
+        "studio": {
+          "id": "452ec40a-3193-4a54-ae89-71105e503a67",
+          "name": "Oconnorport - North, PR",
+          "mbo_studio_id": "29387072",
+          "time_zone": "America/Chicago",
+          "email": "kelliwhite@example.org",
+          "address": {
+            "line1": "40118 Andrea Shoals Suite 808",
+            "city": "North Brucemouth",
+            "state": "OH",
+            "country": "PK",
+            "postal_code": "20180"
+          },
+          "currency_code": "USD",
+          "phone_number": "5815382882",
+          "latitude": 42.046502,
+          "longitude": -93.615804
+        },
+        "coach": {
+          "first_name": "Sarah",
+          "image_url": "https://placeholder.example.com/profile/999999.jpg"
+        }
+      }
     }
   ]
 }

--- a/src/otf_api/models/bookings/bookings_v2.py
+++ b/src/otf_api/models/bookings/bookings_v2.py
@@ -142,6 +142,7 @@ class BookingV2(ApiMixin, OtfItemBase):
     late_canceled: bool | None = None
     canceled_at: datetime | None = None
     ratable: bool
+    waitlist_position: int | None = None
 
     otf_class: BookingV2Class = Field(..., validation_alias="class")
     workout: BookingV2Workout | None = None
@@ -178,6 +179,9 @@ class BookingV2(ApiMixin, OtfItemBase):
 
         if self.canceled:
             return BookingStatus.Cancelled
+
+        if self.waitlist_position is not None:
+            return BookingStatus.Waitlisted
 
         return BookingStatus.Booked
 

--- a/tests/test_api/test_bookings.py
+++ b/tests/test_api/test_bookings.py
@@ -141,7 +141,7 @@ def test_non_waitlisted_booking_never_returns_waitlisted(mock_otf) -> None:
         end_date=date(2026, 4, 26),
     )
 
-    non_waitlisted = [b for b in result if b.booking_id != WAITLISTED_BOOKING_ID]
+    non_waitlisted = [b for b in result if b.waitlist_position is None]
     assert len(non_waitlisted) > 0
 
     for booking in non_waitlisted:

--- a/tests/test_api/test_bookings.py
+++ b/tests/test_api/test_bookings.py
@@ -6,6 +6,7 @@ import httpx
 from conftest import load_fixture
 
 from otf_api.models.bookings import Booking, BookingV2, OtfClass
+from otf_api.models.bookings.enums import BookingStatus
 
 _BOOKINGS_NEW_DATE_PARAMS = "2026-03-27"
 _BOOKINGS_NEW_URL = (
@@ -116,3 +117,33 @@ def test_get_class_from_booking(mock_otf) -> None:
 # get_class_from_booking_new / get_booking_from_class_new cannot be tested:
 # the new booking class IDs (from get_bookings_new fixtures) don't overlap with
 # any class IDs in the get_classes fixture, so the lookup always fails.
+
+WAITLISTED_BOOKING_ID = "a1e2f3d4-5678-4abc-9def-0123456789ab"
+
+
+def test_waitlisted_booking_returns_waitlisted_status(mock_otf) -> None:
+    result = mock_otf.bookings.get_bookings_new(
+        start_date=date(2026, 3, 27),
+        end_date=date(2026, 4, 26),
+    )
+
+    waitlisted = [b for b in result if b.booking_id == WAITLISTED_BOOKING_ID]
+    assert len(waitlisted) == 1
+
+    booking = waitlisted[0]
+    assert booking.waitlist_position == 3
+    assert booking.status == BookingStatus.Waitlisted
+
+
+def test_non_waitlisted_booking_never_returns_waitlisted(mock_otf) -> None:
+    result = mock_otf.bookings.get_bookings_new(
+        start_date=date(2026, 3, 27),
+        end_date=date(2026, 4, 26),
+    )
+
+    non_waitlisted = [b for b in result if b.booking_id != WAITLISTED_BOOKING_ID]
+    assert len(non_waitlisted) > 0
+
+    for booking in non_waitlisted:
+        assert booking.waitlist_position is None
+        assert booking.status != BookingStatus.Waitlisted


### PR DESCRIPTION
## Summary

Fixes #123 — V2 booking status synthesis couldn't distinguish waitlisted bookings from confirmed ones. Both returned `BookingStatus.Booked`.

## Changes

- Added `waitlist_position: int | None` field to `BookingV2` model
- Updated `status` property to return `BookingStatus.Waitlisted` when `waitlist_position is not None` (checked after terminal states, before `Booked` fallback)
- Added waitlisted booking entry to V2 fixture data
- Added 2 tests: waitlisted status detection and non-waitlisted bookings never returning `Waitlisted`

## Design Notes

- Uses `is not None` (not truthiness) so a hypothetical `waitlist_position=0` is correctly treated as waitlisted
- `BookingStatus.Waitlisted` already existed in the enum with priority 2 — no enum changes needed
- Terminal states (`LateCancelled`, `CheckedIn`, `Cancelled`) still take precedence over waitlist status

Closes #123