### PR TITLE
ci: fix CI not running on release-please PRs

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -1,14 +1,13 @@
 name: Test and Lint
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
-
-    env:
-      ACTIONS_RUNNER_DEBUG: true
-      ACTIONS_STEP_DEBUG: true
 
     strategy:
       matrix:
@@ -18,23 +17,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
+          version: "0.7.3"
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}-${{ matrix.python-version }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          curl -LsSf https://astral.sh/uv/0.6.6/install.sh | sh
-          uv sync
+        run: uv sync
 
       - name: Run tests
         run: uv run pytest


### PR DESCRIPTION
## Problem

CI checks never run on release-please PRs (e.g. #120), blocking merge.

**Root cause:** `test_and_lint.yml` only triggered on `push`. The release-please action uses `GITHUB_TOKEN` to create/update its branch, and [pushes made by `GITHUB_TOKEN` don't trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

## Changes

- Add `pull_request` trigger (PR events from `GITHUB_TOKEN` **do** trigger workflows)
- Scope `push` trigger to `main` only (avoids duplicate push+PR runs on feature branches)
- Replace `curl | sh` uv install with `astral-sh/setup-uv@v6` pinned to `0.7.3` (matches `python_package.yml`)
- Remove permanent `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG` flags
- Remove redundant `actions/cache` and `actions/setup-python` steps (handled by `setup-uv`)