### PR TITLE
ci: use github app token for release-please to trigger CI on PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
+          version: "0.7.3"
           enable-cache: true
 
       - name: Sync uv.lock

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,12 +9,64 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: actions/create-github-app-token@v1
+        id: app-token
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  sync-lockfile:
+    needs: release-please
+    if: needs.release-please.outputs.pr && needs.release-please.outputs.release_created != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Sync uv.lock
+        run: |
+          set -euo pipefail
+          uv lock
+          if git diff --quiet uv.lock; then
+              echo "uv.lock is already up to date"
+          else
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git add uv.lock
+              git commit -m "chore: sync uv.lock with version bump"
+              git push origin HEAD
+          fi


### PR DESCRIPTION
PRs created by `GITHUB_TOKEN` (the default) cannot trigger other workflows — this is a GitHub Actions limitation to prevent recursive loops. The release-please PR (#128) has no CI checks running because of this.

**Changes:**
- Use `actions/create-github-app-token` to generate a token from the release-please GitHub App instead of `GITHUB_TOKEN`
- Add `sync-lockfile` job to auto-commit `uv.lock` updates after version bumps (matches hassette pattern)
- Add concurrency group and timeout to prevent stuck runs

**Secrets added:**
- `RELEASE_PLEASE_APP_ID` — GitHub App ID (3267609)
- `RELEASE_PLEASE_APP_PRIVATE_KEY` — GitHub App private key