### PR TITLE
fix: remove component prefix from release-please tags and fix publish workflow

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build and publish (tag, branch, or SHA)"
+        required: true
 
 jobs:
   build-pypi-dists:
@@ -17,8 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.commit }}
-          # Versioneer only generates correct versions with a full fetch
+          ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -51,10 +54,12 @@ jobs:
           path: "./dist"
 
       - name: Upload schema to release
+        continue-on-error: true
         run: |
-          echo "Uploading schema files to release ${{ github.ref_name }}..."
+          REF_NAME="${{ github.event.inputs.ref || github.ref_name }}"
+          echo "Uploading schema files to release ${REF_NAME}..."
 
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${{ github.ref_name }} --jq '.id')
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${REF_NAME} --jq '.id')
           UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/$RELEASE_ID --jq '.upload_url' | sed 's/{?name,label}//')
 
           gh api --method POST "$UPLOAD_URL?name=openapi.yaml" \

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "packages": {
     ".": {
       "package-name": "otf-api",
+      "include-component-in-tag": false,
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
## Problem

release-please was generating tags like `otf-api-v0.19.0` (with a component prefix) but the publish workflow triggers on `v*.*.*` — so v0.16.0 through v0.19.0 never published to PyPI.

## Changes

**release-please-config.json:**
- Added `include-component-in-tag: false` so future tags use `v*.*.*` format

**python_package.yml:**
- Added `ref` input to `workflow_dispatch` for manual builds at specific commits
- Fixed checkout ref (was referencing undefined `commit` input, now uses `inputs.ref || github.ref`)
- Fixed schema upload to use `inputs.ref || github.ref_name` so it finds the correct release during manual dispatch
- Added `continue-on-error: true` to schema upload so it doesn't block PyPI publishing

## After merging

Trigger `workflow_dispatch` for each missed version to backfill PyPI:

| Version | Commit SHA |
|---------|-----------|
| 0.16.0 | `8346056b4770e6b344c31e3ee0c97cc4ccd58f80` |
| 0.17.0 | `bde64b8f526cf59a88f594500380a87e250bf657` |
| 0.18.0 | `73dc04153c69cd7c48d788ce8236b04b75fa32cd` |
| 0.19.0 | `cc711b2a5310e1a721bea33be57b104327d03a16` |