### PR TITLE
fix(ci): resolve schema upload 404 on workflow_dispatch

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git ref to build and publish (tag, branch, or SHA)"
+        description: "Git ref to build and publish. Schema upload only runs if HEAD has a version tag."
         required: true
 
 jobs:
@@ -23,6 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Set up Python
@@ -53,22 +54,37 @@ jobs:
           name: pypi-dists
           path: "./dist"
 
+      - name: Publish schema artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-schema
+          path: "./schema"
+
       - name: Upload schema to release
-        continue-on-error: true
         run: |
-          REF_NAME="${{ github.event.inputs.ref || github.ref_name }}"
-          echo "Uploading schema files to release ${REF_NAME}..."
+          TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
+          if [[ -z "$TAG" ]]; then
+            echo "No tag at HEAD — skipping schema upload (only uploads on tagged releases)"
+            exit 0
+          fi
+          echo "Uploading schema files to release ${TAG}..."
 
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/${REF_NAME} --jq '.id')
-          UPLOAD_URL=$(gh api repos/${{ github.repository }}/releases/$RELEASE_ID --jq '.upload_url' | sed 's/{?name,label}//')
+          for i in 1 2 3; do
+            if gh release view "$TAG" --repo ${{ github.repository }} > /dev/null 2>&1; then
+              break
+            fi
+            echo "Release not found yet (attempt $i/3), waiting 10s..."
+            sleep 10
+          done
 
-          gh api --method POST "$UPLOAD_URL?name=openapi.yaml" \
-            --header "Content-Type: application/x-yaml" \
-            --input ./schema/openapi.yaml
+          if ! gh release view "$TAG" --repo ${{ github.repository }} > /dev/null 2>&1; then
+            echo "Release ${TAG} not found after 3 attempts — cannot upload schema"
+            exit 1
+          fi
 
-          gh api --method POST "$UPLOAD_URL?name=openapi.json" \
-            --header "Content-Type: application/json" \
-            --input ./schema/openapi.json
+          gh release upload "$TAG" ./schema/openapi.yaml ./schema/openapi.json \
+            --repo ${{ github.repository }} \
+            --clobber
 
           echo "Schema files uploaded successfully!"
         env:

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -11,19 +11,14 @@ on:
         required: true
 
 jobs:
-  build-pypi-dists:
-    name: Build Python package & OpenAPI schema
-
+  build:
+    name: Build package & schema
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
-          fetch-depth: 0
-          fetch-tags: true
           persist-credentials: false
 
       - name: Set up Python
@@ -48,24 +43,61 @@ jobs:
       - name: Generate OpenAPI schema
         run: uv run python scripts/generate_openapi.py
 
-      - name: Publish build artifacts
+      - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:
           name: pypi-dists
           path: "./dist"
 
-      - name: Publish schema artifacts
+      - name: Upload schema artifacts
         uses: actions/upload-artifact@v4
+        with:
+          name: openapi-schema
+          path: "./schema"
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/otf-api
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-dists
+          path: "./dist"
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  upload-schema:
+    name: Upload schema to release
+    needs: [build]
+    if: >-
+      startsWith(github.ref, 'refs/tags/v')
+      || (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.ref, 'v'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download schema artifacts
+        uses: actions/download-artifact@v4
         with:
           name: openapi-schema
           path: "./schema"
 
       - name: Upload schema to release
         run: |
-          TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
-          if [[ -z "$TAG" ]]; then
-            echo "No tag at HEAD — skipping schema upload (only uploads on tagged releases)"
-            exit 0
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.ref }}"
+          else
+            TAG="${{ github.ref_name }}"
           fi
           echo "Uploading schema files to release ${TAG}..."
 
@@ -89,23 +121,3 @@ jobs:
           echo "Schema files uploaded successfully!"
         env:
           GH_TOKEN: ${{ github.token }}
-
-  publish-pypi-dists:
-    name: Publish to PyPI
-    environment:
-      name: release
-      url: https://pypi.org/p/otf-api
-    needs: [build-pypi-dists]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
-
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: pypi-dists
-          path: "./dist"
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

The "Upload schema to release" step in the publish workflow used the raw workflow input ref (often a commit SHA) as the release tag name, causing a 404 when looking up the release. This meant schema files were never attached to releases 0.16.0–0.19.0.

## Fix

- Resolve the version tag at HEAD via `git describe --tags --exact-match` instead of relying on workflow inputs
- Skip gracefully when no tag is at HEAD (e.g., workflow_dispatch with a branch/SHA)
- Replace fragile manual `gh api` upload calls with `gh release upload --clobber`
- Add retry loop for release visibility race condition
- Publish schema as a build artifact (always available regardless of release)
- Add `fetch-tags: true` to checkout

## Also done (outside this PR)

Renamed tags `otf-api-v0.16.0`–`otf-api-v0.19.0` → `v0.16.0`–`v0.19.0` and updated the GitHub releases to match. After this merges, run workflow_dispatch with each tag to backfill schemas.