### PR TITLE
feat: add client lifecycle management and stable auth/transport errors

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -62,17 +62,18 @@ otf = Otf()  # Prompts for email and password if OTF_EMAIL/OTF_PASSWORD are not 
 ```python
 from otf_api import Otf
 
-otf = Otf()
+with Otf() as otf:
+    # Member info is loaded lazily on first access
+    print(f"Welcome, {otf.member.first_name}!")
+    print(f"Home studio: {otf.home_studio.name}")
 
-# Member info is loaded lazily on first access
-print(f"Welcome, {otf.member.first_name}!")
-print(f"Home studio: {otf.home_studio.name}")
-
-# Get upcoming classes at your home studio
-classes = otf.bookings.get_classes()
-for otf_class in classes[:5]:
-    print(f"  {otf_class.name} - {otf_class.starts_at}")
+    # Get upcoming classes at your home studio
+    classes = otf.bookings.get_classes()
+    for otf_class in classes[:5]:
+        print(f"  {otf_class.name} - {otf_class.starts_at}")
 ```
+
+`Otf` supports context management (`with` statement) for automatic cleanup of HTTP resources. You can also call `otf.close()` manually, or let the `atexit` handler clean up at process exit.
 
 ## Exploring the API
 

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -85,13 +85,14 @@ except RetryableOtfRequestError as e:
 
 ### OtfAuthenticationError
 
-Raised when authentication with OTF fails — for example, invalid credentials or an expired refresh token that can't be renewed. Wraps the underlying Cognito/botocore error so consumers don't need to import `botocore`.
+Raised when authentication with OTF fails — for example, invalid credentials. Wraps the underlying Cognito/botocore error so consumers don't need to import `botocore`.
 
 ```python
+from otf_api import OtfUser
 from otf_api.exceptions import OtfAuthenticationError
 
 try:
-    otf = Otf(username="bad@example.com", password="wrong")
+    user = OtfUser(username="bad@example.com", password="wrong")
 except OtfAuthenticationError as e:
     print(f"Authentication failed: {e}")
     # The original botocore.exceptions.ClientError is available as e.__cause__

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -8,6 +8,8 @@ All exceptions raised by `otf-api` inherit from a single base class, making it s
 OtfError
 ├── OtfRequestError
 │   └── RetryableOtfRequestError
+├── OtfAuthenticationError
+├── OtfTransportError
 ├── BookingError
 │   ├── AlreadyBookedError
 │   ├── ConflictingBookingError
@@ -26,6 +28,8 @@ from otf_api.exceptions import (
     OtfError,
     OtfRequestError,
     RetryableOtfRequestError,
+    OtfAuthenticationError,
+    OtfTransportError,
     BookingError,
     AlreadyBookedError,
     ConflictingBookingError,
@@ -77,6 +81,34 @@ try:
 except RetryableOtfRequestError as e:
     # The request was retried but still failed
     print(f"Transient failure after retries: {e}")
+```
+
+### OtfAuthenticationError
+
+Raised when authentication with OTF fails — for example, invalid credentials or an expired refresh token that can't be renewed. Wraps the underlying Cognito/botocore error so consumers don't need to import `botocore`.
+
+```python
+from otf_api.exceptions import OtfAuthenticationError
+
+try:
+    otf = Otf(username="bad@example.com", password="wrong")
+except OtfAuthenticationError as e:
+    print(f"Authentication failed: {e}")
+    # The original botocore.exceptions.ClientError is available as e.__cause__
+```
+
+### OtfTransportError
+
+Raised when a network-level error occurs (timeout, connection refused, DNS failure). The library retries transport errors automatically before raising. Wraps the underlying `httpx` exception so consumers don't need to import `httpx`.
+
+```python
+from otf_api.exceptions import OtfTransportError
+
+try:
+    otf.workouts.get_workouts()
+except OtfTransportError as e:
+    print(f"Network error: {e}")
+    # The original httpx exception is available as e.__cause__
 ```
 
 ### BookingError

--- a/src/otf_api/api/api.py
+++ b/src/otf_api/api/api.py
@@ -34,6 +34,7 @@ class Otf:
             user (OtfUser): The user to authenticate as.
         """
         client = OtfClient(user)
+        self._client = client
 
         self.bookings = BookingApi(self, client)
         self.members = MemberApi(self, client)
@@ -42,6 +43,21 @@ class Otf:
         self.trends = TrendApi(self, client)
 
         self._member: models.MemberDetail | None = None
+
+    def close(self) -> None:
+        """Close the underlying HTTP session.
+
+        Safe to call multiple times — subsequent calls are no-ops.
+        """
+        self._client.close()
+
+    def __enter__(self) -> "Otf":
+        """Enter the context manager."""
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_val: BaseException | None, exc_tb: object) -> None:
+        """Exit the context manager and close the HTTP session."""
+        self.close()
 
     @property
     def member_uuid(self) -> str:

--- a/src/otf_api/api/client.py
+++ b/src/otf_api/api/client.py
@@ -53,7 +53,8 @@ class OtfClient:
             headers=HEADERS, auth=self.user.httpx_auth, timeout=httpx.Timeout(20.0, connect=60.0)
         )
         self.log_raw_response = os.getenv("OTF_LOG_RAW_RESPONSE", "false").lower() == "true"
-        atexit.register(self.session.close)
+        self._closed = False
+        atexit.register(self.close)
 
         if os.getenv("OTF_ANONYMIZE_RESPONSES", "false").lower() == "true":
             if not os.getenv("OTF_ANONYMIZE_SEED") and self.member_uuid:
@@ -61,6 +62,15 @@ class OtfClient:
                     os.environ["OTF_ANONYMIZE_SEED"] = str(int(self.member_uuid.replace("-", ""), 16) % (2**32))
             self._anonymize_hook = create_capture_hook()
             self.session.event_hooks["response"].append(self._anonymize_hook)
+
+    def close(self) -> None:
+        """Close the underlying HTTP session.
+
+        Safe to call multiple times — subsequent calls are no-ops.
+        """
+        if not self._closed:
+            self.session.close()
+            self._closed = True
 
     def __getstate__(self):
         """Get the state of the OtfClient instance for serialization."""
@@ -75,7 +85,8 @@ class OtfClient:
         self.session = httpx.Client(
             headers=HEADERS, auth=self.user.httpx_auth, timeout=httpx.Timeout(20.0, connect=60.0)
         )
-        atexit.register(self.session.close)
+        self._closed = False
+        atexit.register(self.close)
 
     def _build_request(
         self,
@@ -90,7 +101,7 @@ class OtfClient:
         return self.session.build_request(method, full_url, headers=headers, params=params, **kwargs)
 
     @retry(
-        retry=retry_if_exception_type((exc.RetryableOtfRequestError, httpx.TimeoutException, httpx.ConnectError)),
+        retry=retry_if_exception_type((exc.RetryableOtfRequestError, exc.OtfTransportError)),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),
         reraise=True,
@@ -131,6 +142,9 @@ class OtfClient:
         except httpx.HTTPStatusError as e:
             json_data = get_json_from_response(e.response)
             self._map_http_error(json_data, e, e.response, request)
+        except httpx.TransportError as e:
+            LOGGER.warning("Transport error on %r %r: %s", request.method, request.url, e)
+            raise exc.OtfTransportError(str(e)) from e
         except Exception as e:
             LOGGER.exception("Unexpected error during %r %r: %s - %s", request.method, request.url, type(e).__name__, e)
             raise

--- a/src/otf_api/auth/auth.py
+++ b/src/otf_api/auth/auth.py
@@ -21,7 +21,7 @@ from pycognito import AWSSRP, Cognito
 from pycognito.aws_srp import generate_hash_device
 
 from otf_api.cache import get_cache
-from otf_api.exceptions import NoCredentialsError
+from otf_api.exceptions import NoCredentialsError, OtfAuthenticationError
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_cognito_identity import CognitoIdentityClient
@@ -330,7 +330,7 @@ class OtfCognito(Cognito):
                 LOGGER.warning("Tokens expired, attempting to login with username and password")
                 CACHE.clear()
                 raise NoCredentialsError("Cached tokens expired, please login again") from e
-            raise
+            raise OtfAuthenticationError(str(e)) from e
 
     def renew_access_token(self) -> None:
         """Sets a new access token on the User using the cached refresh token and device metadata.

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -20,7 +20,7 @@ def _log_initial_auth_error(e: ClientError, username: str | None) -> None:
         LOGGER.exception("Failed to authenticate with Cognito")
 
 
-def _create_cognito(username: str | None, password: str | None, **kwargs) -> OtfCognito:
+def _create_cognito(username: str | None, password: str | None, **kwargs: str | None) -> OtfCognito:
     try:
         return OtfCognito(username=username, password=password, **kwargs)
     except NoCredentialsError:

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -20,6 +20,19 @@ def _log_initial_auth_error(e: ClientError, username: str | None) -> None:
         LOGGER.exception("Failed to authenticate with Cognito")
 
 
+def _create_cognito(username: str | None, password: str | None, **kwargs) -> OtfCognito:
+    try:
+        return OtfCognito(username=username, password=password, **kwargs)
+    except NoCredentialsError:
+        raise
+    except ClientError as e:
+        _log_initial_auth_error(e, username)
+        raise OtfAuthenticationError(str(e)) from e
+    except Exception:
+        LOGGER.exception("Failed to authenticate with Cognito")
+        raise
+
+
 @attrs.define(init=False)
 class OtfUser:
     """OtfUser is a thin wrapper around OtfCognito, meant to hide all of the gory details from end users."""
@@ -51,7 +64,7 @@ class OtfUser:
             NoCredentialsError: If neither username/password nor id/access tokens are provided.
         """
         try:
-            self.cognito = OtfCognito(
+            self.cognito = _create_cognito(
                 username=username,
                 password=password,
                 id_token=id_token,
@@ -61,20 +74,7 @@ class OtfUser:
         except NoCredentialsError:
             LOGGER.debug("No credentials provided, attempting to get them from environment or prompt user")
             username, password = get_username_password()
-            try:
-                self.cognito = OtfCognito(username=username, password=password)
-            except ClientError as e:
-                _log_initial_auth_error(e, username)
-                raise OtfAuthenticationError(str(e)) from e
-            except Exception:
-                LOGGER.exception("Failed to authenticate with Cognito")
-                raise
-        except ClientError as e:
-            _log_initial_auth_error(e, username)
-            raise OtfAuthenticationError(str(e)) from e
-        except Exception:
-            LOGGER.exception("Failed to authenticate with Cognito")
-            raise
+            self.cognito = _create_cognito(username=username, password=password)
 
         self.cognito_id = self.cognito.access_claims["sub"]
         self.member_uuid = self.cognito.id_claims["cognito:username"]

--- a/src/otf_api/auth/user.py
+++ b/src/otf_api/auth/user.py
@@ -5,7 +5,7 @@ from botocore.exceptions import ClientError
 
 from otf_api.auth.auth import HttpxCognitoAuth, OtfCognito
 from otf_api.auth.utils import get_username_password
-from otf_api.exceptions import NoCredentialsError
+from otf_api.exceptions import NoCredentialsError, OtfAuthenticationError
 
 LOGGER = getLogger(__name__)
 
@@ -65,13 +65,13 @@ class OtfUser:
                 self.cognito = OtfCognito(username=username, password=password)
             except ClientError as e:
                 _log_initial_auth_error(e, username)
-                raise
+                raise OtfAuthenticationError(str(e)) from e
             except Exception:
                 LOGGER.exception("Failed to authenticate with Cognito")
                 raise
         except ClientError as e:
             _log_initial_auth_error(e, username)
-            raise
+            raise OtfAuthenticationError(str(e)) from e
         except Exception:
             LOGGER.exception("Failed to authenticate with Cognito")
             raise

--- a/src/otf_api/exceptions.py
+++ b/src/otf_api/exceptions.py
@@ -11,8 +11,10 @@ __all__ = [
     "ClassNotRatableError",
     "ConflictingBookingError",
     "NoCredentialsError",
+    "OtfAuthenticationError",
     "OtfError",
     "OtfRequestError",
+    "OtfTransportError",
     "OutsideSchedulingWindowError",
     "ResourceNotFoundError",
     "RetryableOtfRequestError",
@@ -82,6 +84,20 @@ class AlreadyRatedError(OtfError):
 
 class ClassNotRatableError(OtfError):
     """Raised when attempting to rate a class that is not ratable."""
+
+
+class OtfAuthenticationError(OtfError):
+    """Raised when Cognito authentication fails (e.g., invalid credentials).
+
+    The original error is available via ``__cause__``.
+    """
+
+
+class OtfTransportError(OtfError):
+    """Raised when a network-level error occurs (timeout, connection refused, etc.).
+
+    The original error is available via ``__cause__``.
+    """
 
 
 class NoCredentialsError(OtfError):

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -69,6 +69,12 @@ _MEMOIZED_METHODS: list[tuple[type, str]] = [
 
 
 @pytest.fixture()
+def mock_user():
+    """Yield a mock OtfUser that bypasses Cognito auth."""
+    return _make_mock_user()
+
+
+@pytest.fixture()
 def mock_router():
     """Yield a started respx MockRouter with all fixture routes registered."""
     router = respx.MockRouter(assert_all_called=False, assert_all_mocked=True)

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -68,13 +68,13 @@ _MEMOIZED_METHODS: list[tuple[type, str]] = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_user():
     """Yield a mock OtfUser that bypasses Cognito auth."""
     return _make_mock_user()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_router():
     """Yield a started respx MockRouter with all fixture routes registered."""
     router = respx.MockRouter(assert_all_called=False, assert_all_mocked=True)
@@ -84,7 +84,7 @@ def mock_router():
     router.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_otf(mock_router):
     """Yield a fully wired Otf instance with auth bypassed and HTTP intercepted.
 

--- a/tests/test_api/test_errors.py
+++ b/tests/test_api/test_errors.py
@@ -1,5 +1,6 @@
 """Tests for public error wrapping (OtfAuthenticationError, OtfTransportError)."""
 
+from typing import Never
 from unittest.mock import patch
 
 import httpx
@@ -34,7 +35,7 @@ class TestOtfAuthenticationError:
         call_count = 0
         error = _make_client_error()
 
-        def cognito_side_effect(*args, **kwargs):
+        def cognito_side_effect(**kwargs: object) -> Never:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -60,12 +61,10 @@ class TestOtfTransportError:
             client = OtfClient(user=mock_user)
 
         timeout_error = httpx.ReadTimeout("timed out")
-        with (
-            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
-            pytest.raises(OtfTransportError) as exc_info,
-        ):
+        with respx.mock(assert_all_called=False, assert_all_mocked=True) as router:
             router.get(f"https://{API_BASE_URL}/test").mock(side_effect=timeout_error)
-            client.do("GET", API_BASE_URL, "/test")
+            with pytest.raises(OtfTransportError) as exc_info:
+                client.do("GET", API_BASE_URL, "/test")
 
         assert exc_info.value.__cause__ is timeout_error
 
@@ -74,12 +73,10 @@ class TestOtfTransportError:
             client = OtfClient(user=mock_user)
 
         connect_error = httpx.ConnectError("connection refused")
-        with (
-            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
-            pytest.raises(OtfTransportError) as exc_info,
-        ):
+        with respx.mock(assert_all_called=False, assert_all_mocked=True) as router:
             router.get(f"https://{API_BASE_URL}/test").mock(side_effect=connect_error)
-            client.do("GET", API_BASE_URL, "/test")
+            with pytest.raises(OtfTransportError) as exc_info:
+                client.do("GET", API_BASE_URL, "/test")
 
         assert exc_info.value.__cause__ is connect_error
 
@@ -88,12 +85,10 @@ class TestOtfTransportError:
             client = OtfClient(user=mock_user)
 
         read_error = httpx.ReadError("connection reset")
-        with (
-            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
-            pytest.raises(OtfTransportError) as exc_info,
-        ):
+        with respx.mock(assert_all_called=False, assert_all_mocked=True) as router:
             router.get(f"https://{API_BASE_URL}/test").mock(side_effect=read_error)
-            client.do("GET", API_BASE_URL, "/test")
+            with pytest.raises(OtfTransportError) as exc_info:
+                client.do("GET", API_BASE_URL, "/test")
 
         assert exc_info.value.__cause__ is read_error
 

--- a/tests/test_api/test_errors.py
+++ b/tests/test_api/test_errors.py
@@ -1,0 +1,120 @@
+"""Tests for public error wrapping (OtfAuthenticationError, OtfTransportError)."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from botocore.exceptions import ClientError
+
+from otf_api.api.client import API_BASE_URL, OtfClient
+from otf_api.exceptions import OtfAuthenticationError, OtfTransportError
+
+
+def _make_mock_user() -> MagicMock:
+    mock_user = MagicMock()
+    mock_user.member_uuid = "test-uuid"
+    mock_user.httpx_auth = None
+    return mock_user
+
+
+def _make_client_error(code: str = "NotAuthorizedException", message: str = "bad creds") -> ClientError:
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": message}},
+        operation_name="InitiateAuth",
+    )
+
+
+class TestOtfAuthenticationError:
+    def test_client_error_during_init_raises_auth_error(self):
+        error = _make_client_error()
+        with (
+            patch("otf_api.auth.user.OtfCognito", side_effect=error),
+            pytest.raises(OtfAuthenticationError) as exc_info,
+        ):
+            from otf_api.auth.user import OtfUser
+
+            OtfUser(username="test@example.com", password="wrong")
+
+        assert exc_info.value.__cause__ is error
+
+    def test_client_error_during_fallback_raises_auth_error(self):
+        call_count = 0
+        error = _make_client_error()
+
+        def cognito_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                from otf_api.exceptions import NoCredentialsError
+
+                raise NoCredentialsError("no creds")
+            raise error
+
+        with (
+            patch("otf_api.auth.user.OtfCognito", side_effect=cognito_side_effect),
+            patch("otf_api.auth.user.get_username_password", return_value=("env@test.com", "pass")),
+            pytest.raises(OtfAuthenticationError) as exc_info,
+        ):
+            from otf_api.auth.user import OtfUser
+
+            OtfUser()
+
+        assert exc_info.value.__cause__ is error
+
+    def test_auth_error_is_subclass_of_otf_error(self):
+        from otf_api.exceptions import OtfError
+
+        assert issubclass(OtfAuthenticationError, OtfError)
+
+
+class TestOtfTransportError:
+    def test_timeout_raises_transport_error(self):
+        mock_user = _make_mock_user()
+        with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+            client = OtfClient(user=mock_user)
+
+        timeout_error = httpx.ReadTimeout("timed out")
+        with (
+            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
+            pytest.raises(OtfTransportError) as exc_info,
+        ):
+            router.get(f"https://{API_BASE_URL}/test").mock(side_effect=timeout_error)
+            client.do("GET", API_BASE_URL, "/test")
+
+        assert exc_info.value.__cause__ is timeout_error
+
+    def test_connect_error_raises_transport_error(self):
+        mock_user = _make_mock_user()
+        with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+            client = OtfClient(user=mock_user)
+
+        connect_error = httpx.ConnectError("connection refused")
+        with (
+            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
+            pytest.raises(OtfTransportError) as exc_info,
+        ):
+            router.get(f"https://{API_BASE_URL}/test").mock(side_effect=connect_error)
+            client.do("GET", API_BASE_URL, "/test")
+
+        assert exc_info.value.__cause__ is connect_error
+
+    def test_read_error_raises_transport_error(self):
+        mock_user = _make_mock_user()
+        with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+            client = OtfClient(user=mock_user)
+
+        read_error = httpx.ReadError("connection reset")
+        with (
+            respx.mock(assert_all_called=False, assert_all_mocked=True) as router,
+            pytest.raises(OtfTransportError) as exc_info,
+        ):
+            router.get(f"https://{API_BASE_URL}/test").mock(side_effect=read_error)
+            client.do("GET", API_BASE_URL, "/test")
+
+        assert exc_info.value.__cause__ is read_error
+
+    def test_transport_error_is_subclass_of_otf_error(self):
+        from otf_api.exceptions import OtfError
+
+        assert issubclass(OtfTransportError, OtfError)

--- a/tests/test_api/test_errors.py
+++ b/tests/test_api/test_errors.py
@@ -1,6 +1,6 @@
 """Tests for public error wrapping (OtfAuthenticationError, OtfTransportError)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -8,14 +8,8 @@ import respx
 from botocore.exceptions import ClientError
 
 from otf_api.api.client import API_BASE_URL, OtfClient
-from otf_api.exceptions import OtfAuthenticationError, OtfTransportError
-
-
-def _make_mock_user() -> MagicMock:
-    mock_user = MagicMock()
-    mock_user.member_uuid = "test-uuid"
-    mock_user.httpx_auth = None
-    return mock_user
+from otf_api.auth.user import OtfUser
+from otf_api.exceptions import NoCredentialsError, OtfAuthenticationError, OtfError, OtfTransportError
 
 
 def _make_client_error(code: str = "NotAuthorizedException", message: str = "bad creds") -> ClientError:
@@ -32,8 +26,6 @@ class TestOtfAuthenticationError:
             patch("otf_api.auth.user.OtfCognito", side_effect=error),
             pytest.raises(OtfAuthenticationError) as exc_info,
         ):
-            from otf_api.auth.user import OtfUser
-
             OtfUser(username="test@example.com", password="wrong")
 
         assert exc_info.value.__cause__ is error
@@ -46,8 +38,6 @@ class TestOtfAuthenticationError:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                from otf_api.exceptions import NoCredentialsError
-
                 raise NoCredentialsError("no creds")
             raise error
 
@@ -56,21 +46,16 @@ class TestOtfAuthenticationError:
             patch("otf_api.auth.user.get_username_password", return_value=("env@test.com", "pass")),
             pytest.raises(OtfAuthenticationError) as exc_info,
         ):
-            from otf_api.auth.user import OtfUser
-
             OtfUser()
 
         assert exc_info.value.__cause__ is error
 
     def test_auth_error_is_subclass_of_otf_error(self):
-        from otf_api.exceptions import OtfError
-
         assert issubclass(OtfAuthenticationError, OtfError)
 
 
 class TestOtfTransportError:
-    def test_timeout_raises_transport_error(self):
-        mock_user = _make_mock_user()
+    def test_timeout_raises_transport_error(self, mock_user):
         with patch("otf_api.api.client.OtfUser", return_value=mock_user):
             client = OtfClient(user=mock_user)
 
@@ -84,8 +69,7 @@ class TestOtfTransportError:
 
         assert exc_info.value.__cause__ is timeout_error
 
-    def test_connect_error_raises_transport_error(self):
-        mock_user = _make_mock_user()
+    def test_connect_error_raises_transport_error(self, mock_user):
         with patch("otf_api.api.client.OtfUser", return_value=mock_user):
             client = OtfClient(user=mock_user)
 
@@ -99,8 +83,7 @@ class TestOtfTransportError:
 
         assert exc_info.value.__cause__ is connect_error
 
-    def test_read_error_raises_transport_error(self):
-        mock_user = _make_mock_user()
+    def test_read_error_raises_transport_error(self, mock_user):
         with patch("otf_api.api.client.OtfUser", return_value=mock_user):
             client = OtfClient(user=mock_user)
 
@@ -115,6 +98,4 @@ class TestOtfTransportError:
         assert exc_info.value.__cause__ is read_error
 
     def test_transport_error_is_subclass_of_otf_error(self):
-        from otf_api.exceptions import OtfError
-
         assert issubclass(OtfTransportError, OtfError)

--- a/tests/test_api/test_lifecycle.py
+++ b/tests/test_api/test_lifecycle.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from otf_api.api.api import Otf
 
 
@@ -24,21 +26,20 @@ def test_otf_close_is_idempotent(mock_user):
 
 
 def test_otf_context_manager(mock_user):
-    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
-        with Otf(user=mock_user) as otf:
-            session = otf._client.session
-            assert not session.is_closed
+    with patch("otf_api.api.client.OtfUser", return_value=mock_user), Otf(user=mock_user) as otf:
+        session = otf._client.session
+        assert not session.is_closed
 
     assert session.is_closed
 
 
 def test_otf_context_manager_closes_on_exception(mock_user):
-    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
-        try:
-            with Otf(user=mock_user) as otf:
-                session = otf._client.session
-                raise ValueError("boom")
-        except ValueError:
-            pass
+    with (
+        patch("otf_api.api.client.OtfUser", return_value=mock_user),
+        pytest.raises(ValueError, match="boom"),
+        Otf(user=mock_user) as otf,
+    ):
+        session = otf._client.session
+        raise ValueError("boom")
 
     assert session.is_closed

--- a/tests/test_api/test_lifecycle.py
+++ b/tests/test_api/test_lifecycle.py
@@ -1,0 +1,55 @@
+"""Tests for Otf client lifecycle management (close / context manager)."""
+
+from unittest.mock import MagicMock, patch
+
+from otf_api.api.api import Otf
+
+
+def _make_mock_user() -> MagicMock:
+    mock_user = MagicMock()
+    mock_user.member_uuid = "test-uuid"
+    mock_user.httpx_auth = None
+    return mock_user
+
+
+def test_otf_close_closes_session():
+    mock_user = _make_mock_user()
+    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+        otf = Otf(user=mock_user)
+
+    session = otf._client.session
+    assert not session.is_closed
+    otf.close()
+    assert session.is_closed
+
+
+def test_otf_close_is_idempotent():
+    mock_user = _make_mock_user()
+    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+        otf = Otf(user=mock_user)
+
+    otf.close()
+    otf.close()  # should not raise
+
+
+def test_otf_context_manager():
+    mock_user = _make_mock_user()
+    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+        with Otf(user=mock_user) as otf:
+            session = otf._client.session
+            assert not session.is_closed
+
+    assert session.is_closed
+
+
+def test_otf_context_manager_closes_on_exception():
+    mock_user = _make_mock_user()
+    with patch("otf_api.api.client.OtfUser", return_value=mock_user):
+        try:
+            with Otf(user=mock_user) as otf:
+                session = otf._client.session
+                raise ValueError("boom")
+        except ValueError:
+            pass
+
+    assert session.is_closed

--- a/tests/test_api/test_lifecycle.py
+++ b/tests/test_api/test_lifecycle.py
@@ -1,19 +1,11 @@
 """Tests for Otf client lifecycle management (close / context manager)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from otf_api.api.api import Otf
 
 
-def _make_mock_user() -> MagicMock:
-    mock_user = MagicMock()
-    mock_user.member_uuid = "test-uuid"
-    mock_user.httpx_auth = None
-    return mock_user
-
-
-def test_otf_close_closes_session():
-    mock_user = _make_mock_user()
+def test_otf_close_closes_session(mock_user):
     with patch("otf_api.api.client.OtfUser", return_value=mock_user):
         otf = Otf(user=mock_user)
 
@@ -23,8 +15,7 @@ def test_otf_close_closes_session():
     assert session.is_closed
 
 
-def test_otf_close_is_idempotent():
-    mock_user = _make_mock_user()
+def test_otf_close_is_idempotent(mock_user):
     with patch("otf_api.api.client.OtfUser", return_value=mock_user):
         otf = Otf(user=mock_user)
 
@@ -32,8 +23,7 @@ def test_otf_close_is_idempotent():
     otf.close()  # should not raise
 
 
-def test_otf_context_manager():
-    mock_user = _make_mock_user()
+def test_otf_context_manager(mock_user):
     with patch("otf_api.api.client.OtfUser", return_value=mock_user):
         with Otf(user=mock_user) as otf:
             session = otf._client.session
@@ -42,8 +32,7 @@ def test_otf_context_manager():
     assert session.is_closed
 
 
-def test_otf_context_manager_closes_on_exception():
-    mock_user = _make_mock_user()
+def test_otf_context_manager_closes_on_exception(mock_user):
     with patch("otf_api.api.client.OtfUser", return_value=mock_user):
         try:
             with Otf(user=mock_user) as otf:


### PR DESCRIPTION
### Client lifecycle management

- Added `Otf.close()` and context-manager support (`__enter__`/`__exit__`) so callers can deterministically release the underlying `httpx` session instead of relying solely on the `atexit` handler registered at construction time.
- `OtfClient.close()` is idempotent (`_closed` flag) — safe to call multiple times, including from both an explicit `close()` and the `atexit` fallback.
- Updated the getting-started docs to show `with Otf() as otf:` as the recommended usage pattern, noting `close()` and `atexit` as fallbacks.

### Stable public authentication and transport errors

- Added `OtfAuthenticationError`, raised when Cognito authentication fails (invalid credentials, unrenewable expired tokens), wrapping the underlying `botocore.exceptions.ClientError` so consumers don't need to import `botocore` to catch auth failures.
- Added `OtfTransportError`, raised when `httpx` hits a network-level failure (timeout, connection refused, DNS failure, connection reset), wrapping the underlying `httpx` exception so consumers don't need to import `httpx` directly.
- Both errors expose the original exception via `__cause__` and inherit from `OtfError`, keeping the single-base-class catch-all guarantee documented in `docs/guides/error-handling.md`.
- Widened the retry predicate on `OtfClient.do()` from a fixed list of `httpx` exception types to `exc.OtfTransportError`, so retries stay in sync with whatever transport failures get wrapped rather than drifting from the wrapping logic.
- Consolidated the three near-duplicate `OtfCognito(...)` try/except blocks in `OtfUser.__init__` (initial attempt, `ClientError` handler, env/prompt fallback) into a single `_create_cognito()` helper — cleanup from the first commit's clean-code review.
- Documented both new error types with catch examples in `docs/guides/error-handling.md`.

Closes #137
Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-manager support and explicit session cleanup for safer API usage.
  * Added automatic cleanup when the application exits.
  * Introduced clear authentication and network error types with access to underlying causes.
  * Added automatic retries for transport-related failures.

* **Documentation**
  * Updated getting-started examples with recommended resource cleanup patterns.
  * Documented authentication failures, network errors, retries, and manual cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->